### PR TITLE
[🚀 Feed-Read] 초기 설정 및 필터링 조회 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,8 +44,8 @@ dependencies {
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 
 	// Spring Cloud Config
-//	implementation 'org.springframework.cloud:spring-cloud-starter-config'
-//	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	implementation 'org.springframework.cloud:spring-cloud-starter-config'
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
 	// Kafka
 	implementation 'org.springframework.kafka:spring-kafka'

--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,14 @@ dependencies {
 	// Database
 	implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
 
+	// QueryDSL
+	implementation 'com.querydsl:querydsl-core:5.0.0'
+	implementation('com.querydsl:querydsl-mongodb') {
+		exclude group: 'org.mongodb', module: 'mongo-java-driver'
+	}
+	annotationProcessor 'com.querydsl:querydsl-apt:5.0.0'
+	annotationProcessor 'org.springframework.boot:spring-boot-starter-data-mongodb'
+
 	// Lombok
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
@@ -74,4 +82,10 @@ dependencyManagement {
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+compileJava {
+	options.compilerArgs += [
+			"-processor", 'lombok.launch.AnnotationProcessorHider$AnnotationProcessor,org.springframework.data.mongodb.repository.support.MongoAnnotationProcessor'
+	]
 }

--- a/src/main/java/com/mulmeong/feed/read/FeedReadApplication.java
+++ b/src/main/java/com/mulmeong/feed/read/FeedReadApplication.java
@@ -3,7 +3,9 @@ package com.mulmeong.feed.read;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+import org.springframework.cloud.context.config.annotation.RefreshScope;
 
+@RefreshScope
 @EnableDiscoveryClient
 @SpringBootApplication
 public class FeedReadApplication {

--- a/src/main/java/com/mulmeong/feed/read/api/application/FeedEventHandlerService.java
+++ b/src/main/java/com/mulmeong/feed/read/api/application/FeedEventHandlerService.java
@@ -1,0 +1,9 @@
+package com.mulmeong.feed.read.api.application;
+
+import com.mulmeong.feed.read.api.domain.event.FeedCreateEvent;
+
+public interface FeedEventHandlerService {
+
+    void createFeedFromEvent(FeedCreateEvent event);
+
+}

--- a/src/main/java/com/mulmeong/feed/read/api/application/FeedEventHandlerService.java
+++ b/src/main/java/com/mulmeong/feed/read/api/application/FeedEventHandlerService.java
@@ -2,10 +2,19 @@ package com.mulmeong.feed.read.api.application;
 
 import com.mulmeong.feed.read.api.domain.event.FeedCreateEvent;
 import com.mulmeong.feed.read.api.domain.event.FeedDeleteEvent;
+import com.mulmeong.feed.read.api.domain.event.FeedHashtagUpdateEvent;
+import com.mulmeong.feed.read.api.domain.event.FeedStatusUpdateEvent;
+import com.mulmeong.feed.read.api.domain.event.FeedUpdateEvent;
 
 public interface FeedEventHandlerService {
 
     void createFeedFromEvent(FeedCreateEvent event);
+
+    void updateFeedHashtagFromEvent(FeedHashtagUpdateEvent event);
+
+    void updateFeedStatusFromEvent(FeedStatusUpdateEvent event);
+
+    void updateFeedFromEvent(FeedUpdateEvent event);
 
     void deleteFeedFromEvent(FeedDeleteEvent event);
 

--- a/src/main/java/com/mulmeong/feed/read/api/application/FeedEventHandlerService.java
+++ b/src/main/java/com/mulmeong/feed/read/api/application/FeedEventHandlerService.java
@@ -1,9 +1,12 @@
 package com.mulmeong.feed.read.api.application;
 
 import com.mulmeong.feed.read.api.domain.event.FeedCreateEvent;
+import com.mulmeong.feed.read.api.domain.event.FeedDeleteEvent;
 
 public interface FeedEventHandlerService {
 
     void createFeedFromEvent(FeedCreateEvent event);
+
+    void deleteFeedFromEvent(FeedDeleteEvent event);
 
 }

--- a/src/main/java/com/mulmeong/feed/read/api/application/FeedEventHandlerServiceImpl.java
+++ b/src/main/java/com/mulmeong/feed/read/api/application/FeedEventHandlerServiceImpl.java
@@ -1,6 +1,7 @@
 package com.mulmeong.feed.read.api.application;
 
 import com.mulmeong.feed.read.api.domain.event.FeedCreateEvent;
+import com.mulmeong.feed.read.api.domain.event.FeedDeleteEvent;
 import com.mulmeong.feed.read.api.infrastructure.FeedEventRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -15,6 +16,12 @@ public class FeedEventHandlerServiceImpl implements FeedEventHandlerService {
     public void createFeedFromEvent(FeedCreateEvent event) {
 
         feedEventRepository.save(event.toDocument());
+    }
+
+    @Override
+    public void deleteFeedFromEvent(FeedDeleteEvent event) {
+
+        feedEventRepository.deleteByFeedUuid(event.getFeedUuid());
     }
 
 }

--- a/src/main/java/com/mulmeong/feed/read/api/application/FeedEventHandlerServiceImpl.java
+++ b/src/main/java/com/mulmeong/feed/read/api/application/FeedEventHandlerServiceImpl.java
@@ -10,7 +10,6 @@ import com.mulmeong.feed.read.api.domain.event.FeedUpdateEvent;
 import com.mulmeong.feed.read.api.infrastructure.FeedEventRepository;
 import com.mulmeong.feed.read.common.exception.BaseException;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.stereotype.Service;
 
 @RequiredArgsConstructor
@@ -18,7 +17,6 @@ import org.springframework.stereotype.Service;
 public class FeedEventHandlerServiceImpl implements FeedEventHandlerService {
 
     private final FeedEventRepository feedEventRepository;
-    private final MongoTemplate mongoTemplate;
 
     @Override
     public void createFeedFromEvent(FeedCreateEvent event) {
@@ -50,7 +48,7 @@ public class FeedEventHandlerServiceImpl implements FeedEventHandlerService {
     @Override
     public void deleteFeedFromEvent(FeedDeleteEvent event) {
 
-        feedEventRepository.deleteByFeedUuid(event.getFeedUuid());
+        feedEventRepository.deleteById(event.getFeedUuid());
     }
 
 }

--- a/src/main/java/com/mulmeong/feed/read/api/application/FeedEventHandlerServiceImpl.java
+++ b/src/main/java/com/mulmeong/feed/read/api/application/FeedEventHandlerServiceImpl.java
@@ -27,28 +27,31 @@ public class FeedEventHandlerServiceImpl implements FeedEventHandlerService {
     @Override
     public void updateFeedHashtagFromEvent(FeedHashtagUpdateEvent event) {
 
-        feedEventRepository.save(event.toDocument(feedEventRepository.findById(event.getFeedUuid())
+        feedEventRepository.save(
+            event.toDocument(feedEventRepository.findByFeedUuid(event.getFeedUuid())
                 .orElseThrow(() -> new BaseException(FEED_NOT_FOUND))));
     }
 
     @Override
     public void updateFeedStatusFromEvent(FeedStatusUpdateEvent event) {
 
-        feedEventRepository.save(event.toDocument(feedEventRepository.findById(event.getFeedUuid())
-            .orElseThrow(() -> new BaseException(FEED_NOT_FOUND))));
+        feedEventRepository.save(
+            event.toDocument(feedEventRepository.findByFeedUuid(event.getFeedUuid())
+                .orElseThrow(() -> new BaseException(FEED_NOT_FOUND))));
     }
 
     @Override
     public void updateFeedFromEvent(FeedUpdateEvent event) {
 
-        feedEventRepository.save(event.toDocument(feedEventRepository.findById(event.getFeedUuid())
-            .orElseThrow(() -> new BaseException(FEED_NOT_FOUND))));
+        feedEventRepository.save(
+            event.toDocument(feedEventRepository.findByFeedUuid(event.getFeedUuid())
+                .orElseThrow(() -> new BaseException(FEED_NOT_FOUND))));
     }
 
     @Override
     public void deleteFeedFromEvent(FeedDeleteEvent event) {
 
-        feedEventRepository.deleteById(event.getFeedUuid());
+        feedEventRepository.deleteByFeedUuid(event.getFeedUuid());
     }
 
 }

--- a/src/main/java/com/mulmeong/feed/read/api/application/FeedEventHandlerServiceImpl.java
+++ b/src/main/java/com/mulmeong/feed/read/api/application/FeedEventHandlerServiceImpl.java
@@ -1,9 +1,16 @@
 package com.mulmeong.feed.read.api.application;
 
+import static com.mulmeong.feed.read.common.response.BaseResponseStatus.FEED_NOT_FOUND;
+
 import com.mulmeong.feed.read.api.domain.event.FeedCreateEvent;
 import com.mulmeong.feed.read.api.domain.event.FeedDeleteEvent;
+import com.mulmeong.feed.read.api.domain.event.FeedHashtagUpdateEvent;
+import com.mulmeong.feed.read.api.domain.event.FeedStatusUpdateEvent;
+import com.mulmeong.feed.read.api.domain.event.FeedUpdateEvent;
 import com.mulmeong.feed.read.api.infrastructure.FeedEventRepository;
+import com.mulmeong.feed.read.common.exception.BaseException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.stereotype.Service;
 
 @RequiredArgsConstructor
@@ -11,11 +18,33 @@ import org.springframework.stereotype.Service;
 public class FeedEventHandlerServiceImpl implements FeedEventHandlerService {
 
     private final FeedEventRepository feedEventRepository;
+    private final MongoTemplate mongoTemplate;
 
     @Override
     public void createFeedFromEvent(FeedCreateEvent event) {
 
         feedEventRepository.save(event.toDocument());
+    }
+
+    @Override
+    public void updateFeedHashtagFromEvent(FeedHashtagUpdateEvent event) {
+
+        feedEventRepository.save(event.toDocument(feedEventRepository.findById(event.getFeedUuid())
+                .orElseThrow(() -> new BaseException(FEED_NOT_FOUND))));
+    }
+
+    @Override
+    public void updateFeedStatusFromEvent(FeedStatusUpdateEvent event) {
+
+        feedEventRepository.save(event.toDocument(feedEventRepository.findById(event.getFeedUuid())
+            .orElseThrow(() -> new BaseException(FEED_NOT_FOUND))));
+    }
+
+    @Override
+    public void updateFeedFromEvent(FeedUpdateEvent event) {
+
+        feedEventRepository.save(event.toDocument(feedEventRepository.findById(event.getFeedUuid())
+            .orElseThrow(() -> new BaseException(FEED_NOT_FOUND))));
     }
 
     @Override

--- a/src/main/java/com/mulmeong/feed/read/api/application/FeedEventHandlerServiceImpl.java
+++ b/src/main/java/com/mulmeong/feed/read/api/application/FeedEventHandlerServiceImpl.java
@@ -1,0 +1,20 @@
+package com.mulmeong.feed.read.api.application;
+
+import com.mulmeong.feed.read.api.domain.event.FeedCreateEvent;
+import com.mulmeong.feed.read.api.infrastructure.FeedEventRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class FeedEventHandlerServiceImpl implements FeedEventHandlerService {
+
+    private final FeedEventRepository feedEventRepository;
+
+    @Override
+    public void createFeedFromEvent(FeedCreateEvent event) {
+
+        feedEventRepository.save(event.toDocument());
+    }
+
+}

--- a/src/main/java/com/mulmeong/feed/read/api/application/FeedQueryService.java
+++ b/src/main/java/com/mulmeong/feed/read/api/application/FeedQueryService.java
@@ -1,9 +1,14 @@
 package com.mulmeong.feed.read.api.application;
 
-import com.mulmeong.feed.read.api.dto.FeedResponseDto;
+import com.mulmeong.feed.read.api.dto.in.FeedFilterRequestDto;
+import com.mulmeong.feed.read.api.dto.out.FeedResponseDto;
+import com.mulmeong.feed.read.common.utils.CursorPage;
+import java.util.List;
 
 public interface FeedQueryService {
 
     FeedResponseDto getSingleFeed(String feedUuid);
+
+    CursorPage<FeedResponseDto> getFeedsByCategoryOrTag(FeedFilterRequestDto requestDto);
 
 }

--- a/src/main/java/com/mulmeong/feed/read/api/application/FeedQueryService.java
+++ b/src/main/java/com/mulmeong/feed/read/api/application/FeedQueryService.java
@@ -1,0 +1,5 @@
+package com.mulmeong.feed.read.api.application;
+
+public interface FeedQueryService {
+
+}

--- a/src/main/java/com/mulmeong/feed/read/api/application/FeedQueryService.java
+++ b/src/main/java/com/mulmeong/feed/read/api/application/FeedQueryService.java
@@ -1,14 +1,16 @@
 package com.mulmeong.feed.read.api.application;
 
+import com.mulmeong.feed.read.api.dto.in.FeedAuthorRequestDto;
 import com.mulmeong.feed.read.api.dto.in.FeedFilterRequestDto;
 import com.mulmeong.feed.read.api.dto.out.FeedResponseDto;
 import com.mulmeong.feed.read.common.utils.CursorPage;
-import java.util.List;
 
 public interface FeedQueryService {
 
     FeedResponseDto getSingleFeed(String feedUuid);
 
     CursorPage<FeedResponseDto> getFeedsByCategoryOrTag(FeedFilterRequestDto requestDto);
+
+    CursorPage<FeedResponseDto> getFeedsByAuthor(FeedAuthorRequestDto requestDto);
 
 }

--- a/src/main/java/com/mulmeong/feed/read/api/application/FeedQueryService.java
+++ b/src/main/java/com/mulmeong/feed/read/api/application/FeedQueryService.java
@@ -1,5 +1,9 @@
 package com.mulmeong.feed.read.api.application;
 
+import com.mulmeong.feed.read.api.dto.FeedResponseDto;
+
 public interface FeedQueryService {
+
+    FeedResponseDto getSingleFeed(String feedUuid);
 
 }

--- a/src/main/java/com/mulmeong/feed/read/api/application/FeedQueryServiceImpl.java
+++ b/src/main/java/com/mulmeong/feed/read/api/application/FeedQueryServiceImpl.java
@@ -2,9 +2,12 @@ package com.mulmeong.feed.read.api.application;
 
 import static com.mulmeong.feed.read.common.response.BaseResponseStatus.FEED_NOT_FOUND;
 
-import com.mulmeong.feed.read.api.dto.FeedResponseDto;
+import com.mulmeong.feed.read.api.dto.in.FeedFilterRequestDto;
+import com.mulmeong.feed.read.api.dto.out.FeedResponseDto;
+import com.mulmeong.feed.read.api.infrastructure.FeedCustomRepository;
 import com.mulmeong.feed.read.api.infrastructure.FeedQueryRepository;
 import com.mulmeong.feed.read.common.exception.BaseException;
+import com.mulmeong.feed.read.common.utils.CursorPage;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -14,13 +17,21 @@ import org.springframework.transaction.annotation.Transactional;
 public class FeedQueryServiceImpl implements FeedQueryService {
 
     private final FeedQueryRepository feedQueryRepository;
+    private final FeedCustomRepository feedCustomRepository;
 
-    @Transactional
+    @Transactional(readOnly = true)
     @Override
     public FeedResponseDto getSingleFeed(String feedUuid) {
 
-        return FeedResponseDto.fromDocument(feedQueryRepository.findById(feedUuid)
+        return FeedResponseDto.fromDocument(feedQueryRepository.findByFeedUuid(feedUuid)
             .orElseThrow(() -> new BaseException(FEED_NOT_FOUND)));
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public CursorPage<FeedResponseDto> getFeedsByCategoryOrTag(FeedFilterRequestDto requestDto) {
+
+        return feedCustomRepository.getFeedsByCategoryOrTag(requestDto);
     }
 
 }

--- a/src/main/java/com/mulmeong/feed/read/api/application/FeedQueryServiceImpl.java
+++ b/src/main/java/com/mulmeong/feed/read/api/application/FeedQueryServiceImpl.java
@@ -2,6 +2,7 @@ package com.mulmeong.feed.read.api.application;
 
 import static com.mulmeong.feed.read.common.response.BaseResponseStatus.FEED_NOT_FOUND;
 
+import com.mulmeong.feed.read.api.dto.in.FeedAuthorRequestDto;
 import com.mulmeong.feed.read.api.dto.in.FeedFilterRequestDto;
 import com.mulmeong.feed.read.api.dto.out.FeedResponseDto;
 import com.mulmeong.feed.read.api.infrastructure.FeedCustomRepository;
@@ -32,6 +33,13 @@ public class FeedQueryServiceImpl implements FeedQueryService {
     public CursorPage<FeedResponseDto> getFeedsByCategoryOrTag(FeedFilterRequestDto requestDto) {
 
         return feedCustomRepository.getFeedsByCategoryOrTag(requestDto);
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public CursorPage<FeedResponseDto> getFeedsByAuthor(FeedAuthorRequestDto requestDto) {
+
+        return feedCustomRepository.getFeedsByAuthor(requestDto);
     }
 
 }

--- a/src/main/java/com/mulmeong/feed/read/api/application/FeedQueryServiceImpl.java
+++ b/src/main/java/com/mulmeong/feed/read/api/application/FeedQueryServiceImpl.java
@@ -1,0 +1,26 @@
+package com.mulmeong.feed.read.api.application;
+
+import static com.mulmeong.feed.read.common.response.BaseResponseStatus.FEED_NOT_FOUND;
+
+import com.mulmeong.feed.read.api.dto.FeedResponseDto;
+import com.mulmeong.feed.read.api.infrastructure.FeedQueryRepository;
+import com.mulmeong.feed.read.common.exception.BaseException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class FeedQueryServiceImpl implements FeedQueryService {
+
+    private final FeedQueryRepository feedQueryRepository;
+
+    @Transactional
+    @Override
+    public FeedResponseDto getSingleFeed(String feedUuid) {
+
+        return FeedResponseDto.fromDocument(feedQueryRepository.findById(feedUuid)
+            .orElseThrow(() -> new BaseException(FEED_NOT_FOUND)));
+    }
+
+}

--- a/src/main/java/com/mulmeong/feed/read/api/domain/document/Feed.java
+++ b/src/main/java/com/mulmeong/feed/read/api/domain/document/Feed.java
@@ -1,0 +1,54 @@
+package com.mulmeong.feed.read.api.domain.document;
+
+import com.mulmeong.feed.read.api.domain.model.Hashtag;
+import com.mulmeong.feed.read.api.domain.model.Media;
+import com.mulmeong.feed.read.api.domain.model.Visibility;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Getter
+@NoArgsConstructor
+@Document(collection = "feed")
+public class Feed {
+
+    @Id
+    private String feedUuid;
+    private String memberUuid;
+    private String title;
+    private String content;
+    private String categoryName;
+    private Visibility visibility;
+    private List<Hashtag> hashtags;
+    private List<Media> mediaList;
+    private Long likeCount;
+    private Long dislikeCount;
+    private Long commentCount;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    @Builder
+    public Feed(String feedUuid, String memberUuid, String title, String content,
+        String categoryName, Visibility visibility, List<Hashtag> hashtags, List<Media> mediaList,
+        Long likeCount, Long dislikeCount, Long commentCount, LocalDateTime createdAt,
+        LocalDateTime updatedAt) {
+
+        this.feedUuid = feedUuid;
+        this.memberUuid = memberUuid;
+        this.title = title;
+        this.content = content;
+        this.categoryName = categoryName;
+        this.visibility = visibility;
+        this.hashtags = hashtags;
+        this.mediaList = mediaList;
+        this.likeCount = likeCount;
+        this.dislikeCount = dislikeCount;
+        this.commentCount = commentCount;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+}

--- a/src/main/java/com/mulmeong/feed/read/api/domain/document/Feed.java
+++ b/src/main/java/com/mulmeong/feed/read/api/domain/document/Feed.java
@@ -17,6 +17,7 @@ import org.springframework.data.mongodb.core.mapping.Document;
 public class Feed {
 
     @Id
+    private String id;
     private String feedUuid;
     private String memberUuid;
     private String title;
@@ -27,6 +28,7 @@ public class Feed {
     private List<Media> mediaList;
     private Long likeCount;
     private Long dislikeCount;
+    private Long netLikes;  // likesCount - dislikeCount
     private Long commentCount;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
@@ -34,8 +36,8 @@ public class Feed {
     @Builder
     public Feed(String feedUuid, String memberUuid, String title, String content,
         String categoryName, Visibility visibility, List<Hashtag> hashtags, List<Media> mediaList,
-        Long likeCount, Long dislikeCount, Long commentCount, LocalDateTime createdAt,
-        LocalDateTime updatedAt) {
+        Long likeCount, Long dislikeCount, Long netLikes, Long commentCount,
+        LocalDateTime createdAt, LocalDateTime updatedAt) {
 
         this.feedUuid = feedUuid;
         this.memberUuid = memberUuid;
@@ -47,6 +49,7 @@ public class Feed {
         this.mediaList = mediaList;
         this.likeCount = likeCount;
         this.dislikeCount = dislikeCount;
+        this.netLikes = netLikes;
         this.commentCount = commentCount;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;

--- a/src/main/java/com/mulmeong/feed/read/api/domain/event/FeedCreateEvent.java
+++ b/src/main/java/com/mulmeong/feed/read/api/domain/event/FeedCreateEvent.java
@@ -1,0 +1,45 @@
+package com.mulmeong.feed.read.api.domain.event;
+
+import com.mulmeong.feed.read.api.domain.document.Feed;
+import com.mulmeong.feed.read.api.domain.model.Hashtag;
+import com.mulmeong.feed.read.api.domain.model.Media;
+import com.mulmeong.feed.read.api.domain.model.Visibility;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class FeedCreateEvent {
+
+    private String feedUuid;
+    private String memberUuid;
+    private String title;
+    private String content;
+    private String categoryName;
+    private Visibility visibility;
+    private List<Hashtag> hashtags;
+    private List<Media> mediaList;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public Feed toDocument() {
+        return Feed.builder()
+            .feedUuid(feedUuid)
+            .memberUuid(memberUuid)
+            .title(title)
+            .content(content)
+            .categoryName(categoryName)
+            .visibility(visibility)
+            .hashtags(hashtags)
+            .mediaList(mediaList)
+            .likeCount(0L)
+            .dislikeCount(0L)
+            .commentCount(0L)
+            .createdAt(createdAt)
+            .updatedAt(updatedAt)
+            .build();
+    }
+
+}

--- a/src/main/java/com/mulmeong/feed/read/api/domain/event/FeedCreateEvent.java
+++ b/src/main/java/com/mulmeong/feed/read/api/domain/event/FeedCreateEvent.java
@@ -36,6 +36,7 @@ public class FeedCreateEvent {
             .mediaList(mediaList)
             .likeCount(0L)
             .dislikeCount(0L)
+            .netLikes(0L)
             .commentCount(0L)
             .createdAt(createdAt)
             .updatedAt(updatedAt)

--- a/src/main/java/com/mulmeong/feed/read/api/domain/event/FeedDeleteEvent.java
+++ b/src/main/java/com/mulmeong/feed/read/api/domain/event/FeedDeleteEvent.java
@@ -1,0 +1,12 @@
+package com.mulmeong.feed.read.api.domain.event;
+
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class FeedDeleteEvent {
+
+    private String feedUuid;
+
+}

--- a/src/main/java/com/mulmeong/feed/read/api/domain/event/FeedHashtagUpdateEvent.java
+++ b/src/main/java/com/mulmeong/feed/read/api/domain/event/FeedHashtagUpdateEvent.java
@@ -27,6 +27,7 @@ public class FeedHashtagUpdateEvent {
             .mediaList(existingFeed.getMediaList())
             .likeCount(existingFeed.getLikeCount())
             .dislikeCount(existingFeed.getDislikeCount())
+            .netLikes(existingFeed.getNetLikes())
             .commentCount(existingFeed.getCommentCount())
             .createdAt(existingFeed.getCreatedAt())
             .updatedAt(updatedAt)

--- a/src/main/java/com/mulmeong/feed/read/api/domain/event/FeedHashtagUpdateEvent.java
+++ b/src/main/java/com/mulmeong/feed/read/api/domain/event/FeedHashtagUpdateEvent.java
@@ -1,0 +1,36 @@
+package com.mulmeong.feed.read.api.domain.event;
+
+import com.mulmeong.feed.read.api.domain.document.Feed;
+import com.mulmeong.feed.read.api.domain.model.Hashtag;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class FeedHashtagUpdateEvent {
+
+    private String feedUuid;
+    private List<Hashtag> hashtags;
+    private LocalDateTime updatedAt;
+
+    public Feed toDocument(Feed existingFeed) {
+        return Feed.builder()
+            .feedUuid(feedUuid)
+            .memberUuid(existingFeed.getMemberUuid())
+            .title(existingFeed.getTitle())
+            .content(existingFeed.getContent())
+            .categoryName(existingFeed.getCategoryName())
+            .visibility(existingFeed.getVisibility())
+            .hashtags(hashtags)
+            .mediaList(existingFeed.getMediaList())
+            .likeCount(existingFeed.getLikeCount())
+            .dislikeCount(existingFeed.getDislikeCount())
+            .commentCount(existingFeed.getCommentCount())
+            .createdAt(existingFeed.getCreatedAt())
+            .updatedAt(updatedAt)
+            .build();
+    }
+
+}

--- a/src/main/java/com/mulmeong/feed/read/api/domain/event/FeedStatusUpdateEvent.java
+++ b/src/main/java/com/mulmeong/feed/read/api/domain/event/FeedStatusUpdateEvent.java
@@ -1,0 +1,37 @@
+package com.mulmeong.feed.read.api.domain.event;
+
+import com.mulmeong.feed.read.api.domain.document.Feed;
+import com.mulmeong.feed.read.api.domain.model.Hashtag;
+import com.mulmeong.feed.read.api.domain.model.Visibility;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class FeedStatusUpdateEvent {
+
+    private String feedUuid;
+    private Visibility visibility;
+    private LocalDateTime updatedAt;
+
+    public Feed toDocument(Feed existingFeed) {
+        return Feed.builder()
+            .feedUuid(feedUuid)
+            .memberUuid(existingFeed.getMemberUuid())
+            .title(existingFeed.getTitle())
+            .content(existingFeed.getContent())
+            .categoryName(existingFeed.getCategoryName())
+            .visibility(visibility)
+            .hashtags(existingFeed.getHashtags())
+            .mediaList(existingFeed.getMediaList())
+            .likeCount(existingFeed.getLikeCount())
+            .dislikeCount(existingFeed.getDislikeCount())
+            .commentCount(existingFeed.getCommentCount())
+            .createdAt(existingFeed.getCreatedAt())
+            .updatedAt(updatedAt)
+            .build();
+    }
+
+}

--- a/src/main/java/com/mulmeong/feed/read/api/domain/event/FeedStatusUpdateEvent.java
+++ b/src/main/java/com/mulmeong/feed/read/api/domain/event/FeedStatusUpdateEvent.java
@@ -28,6 +28,7 @@ public class FeedStatusUpdateEvent {
             .mediaList(existingFeed.getMediaList())
             .likeCount(existingFeed.getLikeCount())
             .dislikeCount(existingFeed.getDislikeCount())
+            .netLikes(existingFeed.getNetLikes())
             .commentCount(existingFeed.getCommentCount())
             .createdAt(existingFeed.getCreatedAt())
             .updatedAt(updatedAt)

--- a/src/main/java/com/mulmeong/feed/read/api/domain/event/FeedUpdateEvent.java
+++ b/src/main/java/com/mulmeong/feed/read/api/domain/event/FeedUpdateEvent.java
@@ -27,6 +27,7 @@ public class FeedUpdateEvent {
             .mediaList(existingFeed.getMediaList())
             .likeCount(existingFeed.getLikeCount())
             .dislikeCount(existingFeed.getDislikeCount())
+            .netLikes(existingFeed.getNetLikes())
             .commentCount(existingFeed.getCommentCount())
             .createdAt(existingFeed.getCreatedAt())
             .updatedAt(updatedAt)

--- a/src/main/java/com/mulmeong/feed/read/api/domain/event/FeedUpdateEvent.java
+++ b/src/main/java/com/mulmeong/feed/read/api/domain/event/FeedUpdateEvent.java
@@ -1,0 +1,36 @@
+package com.mulmeong.feed.read.api.domain.event;
+
+import com.mulmeong.feed.read.api.domain.document.Feed;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class FeedUpdateEvent {
+
+    private String feedUuid;
+    private String title;
+    private String content;
+    private String categoryName;
+    private LocalDateTime updatedAt;
+
+    public Feed toDocument(Feed existingFeed) {
+        return Feed.builder()
+            .feedUuid(feedUuid)
+            .memberUuid(existingFeed.getMemberUuid())
+            .title(title)
+            .content(content)
+            .categoryName(categoryName)
+            .visibility(existingFeed.getVisibility())
+            .hashtags(existingFeed.getHashtags())
+            .mediaList(existingFeed.getMediaList())
+            .likeCount(existingFeed.getLikeCount())
+            .dislikeCount(existingFeed.getDislikeCount())
+            .commentCount(existingFeed.getCommentCount())
+            .createdAt(existingFeed.getCreatedAt())
+            .updatedAt(updatedAt)
+            .build();
+    }
+
+}

--- a/src/main/java/com/mulmeong/feed/read/api/domain/model/Hashtag.java
+++ b/src/main/java/com/mulmeong/feed/read/api/domain/model/Hashtag.java
@@ -1,0 +1,18 @@
+package com.mulmeong.feed.read.api.domain.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@Builder
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+public class Hashtag {
+
+    private String name;
+
+}

--- a/src/main/java/com/mulmeong/feed/read/api/domain/model/Media.java
+++ b/src/main/java/com/mulmeong/feed/read/api/domain/model/Media.java
@@ -1,0 +1,25 @@
+package com.mulmeong.feed.read.api.domain.model;
+
+import java.util.Map;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@ToString
+@NoArgsConstructor
+public class Media {
+
+    private String mediaUuid;
+    private MediaType mediaType;
+    private Map<MediaSubtype, MediaInfo> assets;
+
+    @Builder
+    public Media(String mediaUuid, MediaType mediaType, Map<MediaSubtype, MediaInfo> assets) {
+        this.mediaUuid = mediaUuid;
+        this.mediaType = mediaType;
+        this.assets = assets;
+    }
+
+}

--- a/src/main/java/com/mulmeong/feed/read/api/domain/model/MediaInfo.java
+++ b/src/main/java/com/mulmeong/feed/read/api/domain/model/MediaInfo.java
@@ -1,0 +1,22 @@
+package com.mulmeong.feed.read.api.domain.model;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@ToString
+@NoArgsConstructor
+public class MediaInfo {
+
+    private String mediaUrl;
+    private String description;
+
+    @Builder
+    public MediaInfo(String mediaUrl, String description) {
+        this.mediaUrl = mediaUrl;
+        this.description = description;
+    }
+
+}

--- a/src/main/java/com/mulmeong/feed/read/api/domain/model/MediaSubtype.java
+++ b/src/main/java/com/mulmeong/feed/read/api/domain/model/MediaSubtype.java
@@ -1,0 +1,19 @@
+package com.mulmeong.feed.read.api.domain.model;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum MediaSubtype {
+
+    IMAGE("이미지"),
+    VIDEO_THUMBNAIL("비디오 썸네일"),
+    STREAMING_360("360p 스트리밍"),
+    STREAMING_540("540p 스트리밍"),
+    STREAMING_720("HD 스트리밍"),
+    VIDEO_MP4("비디오 압축");
+
+    private final String mediaSubtype;
+
+}

--- a/src/main/java/com/mulmeong/feed/read/api/domain/model/MediaType.java
+++ b/src/main/java/com/mulmeong/feed/read/api/domain/model/MediaType.java
@@ -1,0 +1,15 @@
+package com.mulmeong.feed.read.api.domain.model;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum MediaType {
+
+    IMAGE("이미지"),
+    VIDEO("비디오");
+
+    private final String mediaType;
+
+}

--- a/src/main/java/com/mulmeong/feed/read/api/domain/model/SortType.java
+++ b/src/main/java/com/mulmeong/feed/read/api/domain/model/SortType.java
@@ -1,0 +1,15 @@
+package com.mulmeong.feed.read.api.domain.model;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum SortType {
+
+    LATEST("최신순"),
+    LIKES("좋아요순");
+
+    private final String sortType;
+
+}

--- a/src/main/java/com/mulmeong/feed/read/api/domain/model/Visibility.java
+++ b/src/main/java/com/mulmeong/feed/read/api/domain/model/Visibility.java
@@ -1,0 +1,16 @@
+package com.mulmeong.feed.read.api.domain.model;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Visibility {
+
+    VISIBLE("공개"),
+    HIDDEN("비공개"),
+    REPORTED("신고 처리됨");
+
+    private final String visibility;
+
+}

--- a/src/main/java/com/mulmeong/feed/read/api/dto/FeedResponseDto.java
+++ b/src/main/java/com/mulmeong/feed/read/api/dto/FeedResponseDto.java
@@ -1,0 +1,68 @@
+package com.mulmeong.feed.read.api.dto;
+
+import com.mulmeong.feed.read.api.domain.document.Feed;
+import com.mulmeong.feed.read.api.domain.model.Hashtag;
+import com.mulmeong.feed.read.api.domain.model.Media;
+import com.mulmeong.feed.read.api.domain.model.Visibility;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class FeedResponseDto {
+
+    private String feedUuid;
+    private String memberUuid;
+    private String title;
+    private String content;
+    private String categoryName;
+    private Visibility visibility;
+    private List<Hashtag> hashtags;
+    private List<Media> mediaList;
+    private Long likeCount;
+    private Long dislikeCount;
+    private Long commentCount;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public static FeedResponseDto fromDocument(Feed feed) {
+        return FeedResponseDto.builder()
+            .feedUuid(feed.getFeedUuid())
+            .memberUuid(feed.getMemberUuid())
+            .title(feed.getTitle())
+            .content(feed.getContent())
+            .categoryName(feed.getCategoryName())
+            .visibility(feed.getVisibility())
+            .hashtags(feed.getHashtags())
+            .mediaList(feed.getMediaList())
+            .likeCount(feed.getLikeCount())
+            .dislikeCount(feed.getDislikeCount())
+            .commentCount(feed.getCommentCount())
+            .createdAt(feed.getCreatedAt())
+            .updatedAt(feed.getUpdatedAt())
+            .build();
+    }
+
+    @Builder
+    public FeedResponseDto(String feedUuid, String memberUuid, String title, String content,
+        String categoryName, Visibility visibility, List<Media> mediaList, List<Hashtag> hashtags,
+        Long likeCount, Long commentCount, Long dislikeCount, LocalDateTime createdAt,
+        LocalDateTime updatedAt) {
+
+        this.feedUuid = feedUuid;
+        this.memberUuid = memberUuid;
+        this.title = title;
+        this.content = content;
+        this.categoryName = categoryName;
+        this.visibility = visibility;
+        this.mediaList = mediaList;
+        this.hashtags = hashtags;
+        this.likeCount = likeCount;
+        this.commentCount = commentCount;
+        this.dislikeCount = dislikeCount;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+}

--- a/src/main/java/com/mulmeong/feed/read/api/dto/in/FeedAuthorRequestDto.java
+++ b/src/main/java/com/mulmeong/feed/read/api/dto/in/FeedAuthorRequestDto.java
@@ -6,17 +6,17 @@ import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-public class FeedFilterRequestDto extends BasePaginationRequestDto {
+public class FeedAuthorRequestDto extends BasePaginationRequestDto {
 
-    private String categoryName;
-    private String hashtagName;
+    private String authorUuid;
+    private String requesterUuid;
 
-    public static FeedFilterRequestDto toDto(String categoryName, String hashtagName, String sortBy,
+    public static FeedAuthorRequestDto toDto(String authorUuid, String requesterUuid, String sortBy,
         String lastId, Integer pageSize, Integer pageNo) {
 
-        return FeedFilterRequestDto.builder()
-            .categoryName(categoryName)
-            .hashtagName(hashtagName)
+        return FeedAuthorRequestDto.builder()
+            .authorUuid(authorUuid)
+            .requesterUuid(requesterUuid)
             .sortType(SortType.valueOf(sortBy.toUpperCase()))
             .lastId(lastId)
             .pageSize(pageSize)
@@ -25,12 +25,12 @@ public class FeedFilterRequestDto extends BasePaginationRequestDto {
     }
 
     @Builder
-    public FeedFilterRequestDto(String hashtagName, SortType sortType, String categoryName,
+    public FeedAuthorRequestDto(String authorUuid, String requesterUuid, SortType sortType,
         String lastId, Integer pageSize, Integer pageNo) {
 
         super(sortType, lastId, pageSize, pageNo);
-        this.hashtagName = hashtagName;
-        this.categoryName = categoryName;
+        this.authorUuid = authorUuid;
+        this.requesterUuid = requesterUuid;
     }
 
 }

--- a/src/main/java/com/mulmeong/feed/read/api/dto/in/FeedFilterRequestDto.java
+++ b/src/main/java/com/mulmeong/feed/read/api/dto/in/FeedFilterRequestDto.java
@@ -1,0 +1,42 @@
+package com.mulmeong.feed.read.api.dto.in;
+
+import com.mulmeong.feed.read.api.domain.model.SortType;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class FeedFilterRequestDto {
+
+    private String categoryName;
+    private String hashtagName;
+    private SortType sortType;
+    private String lastId;
+    private Integer pageSize;
+    private Integer pageNo;
+
+    public static FeedFilterRequestDto toDto(String categoryName, String hashtagName, String sortBy,
+        String lastId, Integer pageSize, Integer pageNo) {
+
+        return FeedFilterRequestDto.builder()
+            .categoryName(categoryName)
+            .hashtagName(hashtagName)
+            .sortType(SortType.valueOf(sortBy.toUpperCase()))
+            .lastId(lastId)
+            .pageSize(pageSize)
+            .pageNo(pageNo)
+            .build();
+    }
+
+    @Builder
+    public FeedFilterRequestDto(String hashtagName, SortType sortType, String categoryName,
+        String lastId, Integer pageSize, Integer pageNo) {
+
+        this.hashtagName = hashtagName;
+        this.sortType = sortType;
+        this.categoryName = categoryName;
+        this.lastId = lastId;
+        this.pageSize = pageSize;
+        this.pageNo = pageNo;
+    }
+
+}

--- a/src/main/java/com/mulmeong/feed/read/api/dto/model/BasePaginationRequestDto.java
+++ b/src/main/java/com/mulmeong/feed/read/api/dto/model/BasePaginationRequestDto.java
@@ -1,0 +1,16 @@
+package com.mulmeong.feed.read.api.dto.model;
+
+import com.mulmeong.feed.read.api.domain.model.SortType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public abstract class BasePaginationRequestDto {
+
+    private SortType sortType;
+    private String lastId;
+    private Integer pageSize;
+    private Integer pageNo;
+
+}

--- a/src/main/java/com/mulmeong/feed/read/api/dto/out/FeedResponseDto.java
+++ b/src/main/java/com/mulmeong/feed/read/api/dto/out/FeedResponseDto.java
@@ -1,4 +1,4 @@
-package com.mulmeong.feed.read.api.dto;
+package com.mulmeong.feed.read.api.dto.out;
 
 import com.mulmeong.feed.read.api.domain.document.Feed;
 import com.mulmeong.feed.read.api.domain.model.Hashtag;

--- a/src/main/java/com/mulmeong/feed/read/api/infrastructure/FeedCustomRepository.java
+++ b/src/main/java/com/mulmeong/feed/read/api/infrastructure/FeedCustomRepository.java
@@ -1,0 +1,77 @@
+package com.mulmeong.feed.read.api.infrastructure;
+
+import com.mulmeong.feed.read.api.domain.document.Feed;
+import com.mulmeong.feed.read.api.domain.document.QFeed;
+import com.mulmeong.feed.read.api.domain.model.SortType;
+import com.mulmeong.feed.read.api.domain.model.Visibility;
+import com.mulmeong.feed.read.api.dto.in.FeedFilterRequestDto;
+import com.mulmeong.feed.read.api.dto.out.FeedResponseDto;
+import com.mulmeong.feed.read.common.utils.CursorPage;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.OrderSpecifier;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.repository.support.SpringDataMongodbQuery;
+import org.springframework.stereotype.Repository;
+
+@RequiredArgsConstructor
+@Repository
+public class FeedCustomRepository {     // QueryDSL Repository
+
+    private static final int DEFAULT_PAGE_SIZE = 20;
+    private static final int DEFAULT_PAGE_NUMBER = 0;
+
+    private final MongoTemplate mongoTemplate;
+    private final QFeed feed = QFeed.feed;
+
+    public CursorPage<FeedResponseDto> getFeedsByCategoryOrTag(FeedFilterRequestDto requestDto) {
+
+        BooleanBuilder builder = new BooleanBuilder();
+
+        builder.and(feed.visibility.eq(Visibility.VISIBLE));
+
+        Optional.ofNullable(requestDto.getCategoryName()).ifPresent(category ->
+            builder.and(feed.categoryName.eq(category)));
+        Optional.ofNullable(requestDto.getHashtagName()).ifPresent(hashtag ->
+            builder.and(feed.hashtags.any().name.eq(hashtag)));
+
+        // 마지막 ID 커서 적용
+        Optional.ofNullable(requestDto.getLastId()).ifPresent(id -> builder.and(feed.id.lt(id)));
+
+        int curPageNo = Optional.ofNullable(requestDto.getPageNo()).orElse(DEFAULT_PAGE_NUMBER);
+        int curPageSize = Optional.ofNullable(requestDto.getPageSize()).orElse(DEFAULT_PAGE_SIZE);
+        int offset = Math.max(0, (curPageNo - 1) * curPageSize);
+
+        SpringDataMongodbQuery<Feed> query = new SpringDataMongodbQuery<>(mongoTemplate,
+            Feed.class);
+
+        List<Feed> content = query.where(builder)
+            .orderBy(determineSortOrder(feed, requestDto.getSortType()))
+            .offset(offset)
+            .limit(curPageSize + 1)
+            .fetch();
+
+        String nextCursor = null;
+        boolean hasNext = false;
+
+        if (content.size() > curPageSize) {
+            hasNext = true;
+            nextCursor = content.get(curPageSize).getId();  // 마지막 항목의 ID를 커서로 설정
+            content = content.subList(0, curPageSize);      // 실제 페이지 사이즈 만큼 자르기
+        }
+
+        return new CursorPage<>(content.stream().map(FeedResponseDto::fromDocument).toList(),
+            nextCursor, hasNext, content.size(), requestDto.getPageNo());
+    }
+
+    private OrderSpecifier<?> determineSortOrder(QFeed feed, SortType sortType) {
+
+        return switch (sortType) {
+            case LATEST -> feed.createdAt.desc();
+            case LIKES -> feed.netLikes.desc();
+        };
+    }
+
+}

--- a/src/main/java/com/mulmeong/feed/read/api/infrastructure/FeedEventRepository.java
+++ b/src/main/java/com/mulmeong/feed/read/api/infrastructure/FeedEventRepository.java
@@ -5,4 +5,6 @@ import org.springframework.data.mongodb.repository.MongoRepository;
 
 public interface FeedEventRepository extends MongoRepository<Feed, String> {
 
+    void deleteByFeedUuid(String feedUuid);
+
 }

--- a/src/main/java/com/mulmeong/feed/read/api/infrastructure/FeedEventRepository.java
+++ b/src/main/java/com/mulmeong/feed/read/api/infrastructure/FeedEventRepository.java
@@ -1,0 +1,8 @@
+package com.mulmeong.feed.read.api.infrastructure;
+
+import com.mulmeong.feed.read.api.domain.document.Feed;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface FeedEventRepository extends MongoRepository<Feed, String> {
+
+}

--- a/src/main/java/com/mulmeong/feed/read/api/infrastructure/FeedEventRepository.java
+++ b/src/main/java/com/mulmeong/feed/read/api/infrastructure/FeedEventRepository.java
@@ -1,8 +1,13 @@
 package com.mulmeong.feed.read.api.infrastructure;
 
 import com.mulmeong.feed.read.api.domain.document.Feed;
+import java.util.Optional;
 import org.springframework.data.mongodb.repository.MongoRepository;
 
 public interface FeedEventRepository extends MongoRepository<Feed, String> {
+
+    Optional<Feed> findByFeedUuid(String feedUuid);
+
+    void deleteByFeedUuid(String feedUuid);
 
 }

--- a/src/main/java/com/mulmeong/feed/read/api/infrastructure/FeedQueryRepository.java
+++ b/src/main/java/com/mulmeong/feed/read/api/infrastructure/FeedQueryRepository.java
@@ -1,8 +1,11 @@
 package com.mulmeong.feed.read.api.infrastructure;
 
 import com.mulmeong.feed.read.api.domain.document.Feed;
+import java.util.Optional;
 import org.springframework.data.mongodb.repository.MongoRepository;
 
 public interface FeedQueryRepository extends MongoRepository<Feed, String> {
+
+    Optional<Feed> findByFeedUuid(String feedUuid);
 
 }

--- a/src/main/java/com/mulmeong/feed/read/api/infrastructure/FeedQueryRepository.java
+++ b/src/main/java/com/mulmeong/feed/read/api/infrastructure/FeedQueryRepository.java
@@ -3,6 +3,6 @@ package com.mulmeong.feed.read.api.infrastructure;
 import com.mulmeong.feed.read.api.domain.document.Feed;
 import org.springframework.data.mongodb.repository.MongoRepository;
 
-public interface FeedEventRepository extends MongoRepository<Feed, String> {
+public interface FeedQueryRepository extends MongoRepository<Feed, String> {
 
 }

--- a/src/main/java/com/mulmeong/feed/read/api/infrastructure/KafkaConsumer.java
+++ b/src/main/java/com/mulmeong/feed/read/api/infrastructure/KafkaConsumer.java
@@ -2,6 +2,7 @@ package com.mulmeong.feed.read.api.infrastructure;
 
 import com.mulmeong.feed.read.api.application.FeedEventHandlerService;
 import com.mulmeong.feed.read.api.domain.event.FeedCreateEvent;
+import com.mulmeong.feed.read.api.domain.event.FeedDeleteEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
@@ -20,6 +21,14 @@ public class KafkaConsumer {
         log.info("Consumed feed-created event: {}", event);
         feedEventHandlerService.createFeedFromEvent(event);
         log.info("Successfully processed feed-created event: {}", event);
+    }
+
+    @KafkaListener(topics = "feed-deleted", groupId = "feed-read-group", containerFactory = "feedDeleteEventListener")
+    public void consumeFeedDeleteEvent(FeedDeleteEvent event) {
+
+        log.info("Consumed feed-deleted event: {}", event);
+        feedEventHandlerService.deleteFeedFromEvent(event);
+        log.info("Successfully processed feed-deleted event: {}", event);
     }
 
 }

--- a/src/main/java/com/mulmeong/feed/read/api/infrastructure/KafkaConsumer.java
+++ b/src/main/java/com/mulmeong/feed/read/api/infrastructure/KafkaConsumer.java
@@ -18,7 +18,7 @@ public class KafkaConsumer {
 
     private final FeedEventHandlerService feedEventHandlerService;
 
-    @KafkaListener(topics = "feed-created", groupId = "feed-read-group",
+    @KafkaListener(topics = "${event.feed.pub.topics.feed-create.name}",
         containerFactory = "feedCreateEventListener")
     public void consumeFeedCreateEvent(FeedCreateEvent event) {
 
@@ -27,7 +27,7 @@ public class KafkaConsumer {
         log.info("Successfully processed feed-created event: {}", event);
     }
 
-    @KafkaListener(topics = "feed-deleted", groupId = "feed-read-group",
+    @KafkaListener(topics = "${event.feed.pub.topics.feed-delete.name}",
         containerFactory = "feedDeleteEventListener")
     public void consumeFeedDeleteEvent(FeedDeleteEvent event) {
 
@@ -36,7 +36,7 @@ public class KafkaConsumer {
         log.info("Successfully processed feed-deleted event: {}", event);
     }
 
-    @KafkaListener(topics = "feed-hashtag-updated", groupId = "feed-read-group",
+    @KafkaListener(topics = "${event.feed.pub.topics.feed-hashtag-update.name}",
         containerFactory = "feedHashtagUpdateEventListener")
     public void consumeFeedHashtagUpdateEvent(FeedHashtagUpdateEvent event) {
 
@@ -45,7 +45,7 @@ public class KafkaConsumer {
         log.info("Successfully processed feed-hashtag-updated event: {}", event);
     }
 
-    @KafkaListener(topics = "feed-status-updated", groupId = "feed-read-group",
+    @KafkaListener(topics = "${event.feed.pub.topics.feed-status-update.name}",
         containerFactory = "feedStatusUpdateEventListener")
     public void consumeFeedStatusUpdateEvent(FeedStatusUpdateEvent event) {
 
@@ -54,7 +54,7 @@ public class KafkaConsumer {
         log.info("Successfully processed feed-status-updated event: {}", event);
     }
 
-    @KafkaListener(topics = "feed-updated", groupId = "feed-read-group",
+    @KafkaListener(topics = "${event.feed.pub.topics.feed-update.name}",
         containerFactory = "feedUpdateEventListener")
     public void consumeFeedUpdateEvent(FeedUpdateEvent event) {
 

--- a/src/main/java/com/mulmeong/feed/read/api/infrastructure/KafkaConsumer.java
+++ b/src/main/java/com/mulmeong/feed/read/api/infrastructure/KafkaConsumer.java
@@ -3,6 +3,9 @@ package com.mulmeong.feed.read.api.infrastructure;
 import com.mulmeong.feed.read.api.application.FeedEventHandlerService;
 import com.mulmeong.feed.read.api.domain.event.FeedCreateEvent;
 import com.mulmeong.feed.read.api.domain.event.FeedDeleteEvent;
+import com.mulmeong.feed.read.api.domain.event.FeedHashtagUpdateEvent;
+import com.mulmeong.feed.read.api.domain.event.FeedStatusUpdateEvent;
+import com.mulmeong.feed.read.api.domain.event.FeedUpdateEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
@@ -15,7 +18,8 @@ public class KafkaConsumer {
 
     private final FeedEventHandlerService feedEventHandlerService;
 
-    @KafkaListener(topics = "feed-created", groupId = "feed-read-group", containerFactory = "feedCreateEventListener")
+    @KafkaListener(topics = "feed-created", groupId = "feed-read-group",
+        containerFactory = "feedCreateEventListener")
     public void consumeFeedCreateEvent(FeedCreateEvent event) {
 
         log.info("Consumed feed-created event: {}", event);
@@ -23,12 +27,40 @@ public class KafkaConsumer {
         log.info("Successfully processed feed-created event: {}", event);
     }
 
-    @KafkaListener(topics = "feed-deleted", groupId = "feed-read-group", containerFactory = "feedDeleteEventListener")
+    @KafkaListener(topics = "feed-deleted", groupId = "feed-read-group",
+        containerFactory = "feedDeleteEventListener")
     public void consumeFeedDeleteEvent(FeedDeleteEvent event) {
 
         log.info("Consumed feed-deleted event: {}", event);
         feedEventHandlerService.deleteFeedFromEvent(event);
         log.info("Successfully processed feed-deleted event: {}", event);
+    }
+
+    @KafkaListener(topics = "feed-hashtag-updated", groupId = "feed-read-group",
+        containerFactory = "feedHashtagUpdateEventListener")
+    public void consumeFeedHashtagUpdateEvent(FeedHashtagUpdateEvent event) {
+
+        log.info("Consumed feed-hashtag-updated event: {}", event);
+        feedEventHandlerService.updateFeedHashtagFromEvent(event);
+        log.info("Successfully processed feed-hashtag-updated event: {}", event);
+    }
+
+    @KafkaListener(topics = "feed-status-updated", groupId = "feed-read-group",
+        containerFactory = "feedStatusUpdateEventListener")
+    public void consumeFeedStatusUpdateEvent(FeedStatusUpdateEvent event) {
+
+        log.info("Consumed feed-status-updated event: {}", event);
+        feedEventHandlerService.updateFeedStatusFromEvent(event);
+        log.info("Successfully processed feed-status-updated event: {}", event);
+    }
+
+    @KafkaListener(topics = "feed-updated", groupId = "feed-read-group",
+        containerFactory = "feedUpdateEventListener")
+    public void consumeFeedUpdateEvent(FeedUpdateEvent event) {
+
+        log.info("Consumed feed-updated event: {}", event);
+        feedEventHandlerService.updateFeedFromEvent(event);
+        log.info("Successfully processed feed-updated event: {}", event);
     }
 
 }

--- a/src/main/java/com/mulmeong/feed/read/api/infrastructure/KafkaConsumer.java
+++ b/src/main/java/com/mulmeong/feed/read/api/infrastructure/KafkaConsumer.java
@@ -1,0 +1,25 @@
+package com.mulmeong.feed.read.api.infrastructure;
+
+import com.mulmeong.feed.read.api.application.FeedEventHandlerService;
+import com.mulmeong.feed.read.api.domain.event.FeedCreateEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class KafkaConsumer {
+
+    private final FeedEventHandlerService feedEventHandlerService;
+
+    @KafkaListener(topics = "feed-created", groupId = "feed-read-group", containerFactory = "feedCreateEventListener")
+    public void consumeFeedCreateEvent(FeedCreateEvent event) {
+
+        log.info("Consumed feed-created event: {}", event);
+        feedEventHandlerService.createFeedFromEvent(event);
+        log.info("Successfully processed feed-created event: {}", event);
+    }
+
+}

--- a/src/main/java/com/mulmeong/feed/read/api/presentation/AuthRequiredFeedQueryController.java
+++ b/src/main/java/com/mulmeong/feed/read/api/presentation/AuthRequiredFeedQueryController.java
@@ -1,0 +1,44 @@
+package com.mulmeong.feed.read.api.presentation;
+
+import com.mulmeong.feed.read.api.application.FeedQueryService;
+import com.mulmeong.feed.read.api.dto.in.FeedAuthorRequestDto;
+import com.mulmeong.feed.read.api.dto.out.FeedResponseDto;
+import com.mulmeong.feed.read.common.response.BaseResponse;
+import com.mulmeong.feed.read.common.utils.CursorPage;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Auth Required Feed")
+@RequiredArgsConstructor
+@RequestMapping("/auth/v1/members")
+@RestController
+public class AuthRequiredFeedQueryController {
+
+    private final FeedQueryService feedQueryService;
+
+    @Operation(summary = "특정 사용자가 작성한 피드 목록 조회",
+        description = """
+            - **요청자와 작성자의 memberUuid가 같으면** 조건에 맞는 모든 Feed를,
+            같지 않으면 Visibility = `VISIBLE`인 Feed만을 조회<br><br>
+            - sortBy: `LATEST` / `LIKES` (대·소문자 구분하지 않음)<br><br>
+            - LATEST: **최신순**, LIKES: **netLikes 내림차순** (likesCount - dislikeCount)""")
+    @GetMapping("/{memberUuid}/feeds")
+    public BaseResponse<CursorPage<FeedResponseDto>> getFeedsByAuthor(
+        @PathVariable(name = "memberUuid") String authorUuid,
+        @RequestHeader("Member-Uuid") String requesterUuid,
+        @RequestParam(defaultValue = "latest", required = false) String sortBy,
+        @RequestParam(required = false, name = "nextCursor") String lastId,
+        @RequestParam(required = false) Integer pageSize,
+        @RequestParam(required = false) Integer pageNo) {
+
+        return new BaseResponse<>(feedQueryService.getFeedsByAuthor(FeedAuthorRequestDto.toDto(
+            authorUuid, requesterUuid, sortBy, lastId, pageSize, pageNo)));
+    }
+}

--- a/src/main/java/com/mulmeong/feed/read/api/presentation/FeedQueryController.java
+++ b/src/main/java/com/mulmeong/feed/read/api/presentation/FeedQueryController.java
@@ -24,7 +24,11 @@ public class FeedQueryController {
 
     private final FeedQueryService feedQueryService;
 
-    @Operation(summary = "Feed 단건 정보 조회 API", description = "feedUuid 기준 **Feed Detail 조회**")
+    @Operation(summary = "Feed 단건 정보 조회 API", description = """
+        - Visibility: `VISIBLE` / `HIDDEN` / `REPORTED`<br>
+        - MediaType: `IMAGE` / `VIDEO`<br>
+        - MediaSubType: `IMAGE` / `VIDEO_THUMBNAIL` / `VIDEO_360` / `VIDEO_540` / `VIDEO_720` / `VIDEO_MP4`<br><br>
+        - FeedMedia 테이블은 **FE에서 생성한 MediaUUID를 기본키로 설정**하는 것에 주의""")
     @GetMapping("/{feedUuid}")
     public BaseResponse<FeedResponseDto> getSingleFeed(@PathVariable String feedUuid) {
 
@@ -32,8 +36,10 @@ public class FeedQueryController {
     }
 
     @Operation(summary = "(특정 카테고리 / 특정 해시태그)의 (최신순 / 좋아요순) 피드 목록 조회 API",
-        description = "sortBy: `LATEST` / `LIKES` (대·소문자 구분하지 않음)<br><br>"
-                      + "LATEST: **최신순**, LIKES: **netLikes 내림차순** (likesCount - dislikeCount)")
+        description = """
+            - sortBy: `LATEST` / `LIKES` (대·소문자 구분하지 않음)<br><br>
+            - LATEST: **최신순**, LIKES: **netLikes 내림차순** (likesCount - dislikeCount)<br><br>
+            - Visibility: `VISIBLE`인 피드 목록만 조회""")
     @GetMapping
     public BaseResponse<CursorPage<FeedResponseDto>> getFeedsByCategoryOrTag(
         @RequestParam(required = false) String categoryName,

--- a/src/main/java/com/mulmeong/feed/read/api/presentation/FeedQueryController.java
+++ b/src/main/java/com/mulmeong/feed/read/api/presentation/FeedQueryController.java
@@ -1,0 +1,29 @@
+package com.mulmeong.feed.read.api.presentation;
+
+import com.mulmeong.feed.read.api.application.FeedQueryService;
+import com.mulmeong.feed.read.api.dto.FeedResponseDto;
+import com.mulmeong.feed.read.common.response.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Feed Query")
+@RequiredArgsConstructor
+@RequestMapping("/v1/feeds")
+@RestController
+public class FeedQueryController {
+
+    private final FeedQueryService feedQueryService;
+
+    @Operation(summary = "Feed 단건 정보 조회 API", description = "feedUuid 기준 **Feed Detail 조회**")
+    @GetMapping("/{feedUuid}")
+    public BaseResponse<FeedResponseDto> getSingleFeed(@PathVariable String feedUuid) {
+
+        return new BaseResponse<>(feedQueryService.getSingleFeed(feedUuid));
+    }
+
+}

--- a/src/main/java/com/mulmeong/feed/read/api/presentation/FeedQueryController.java
+++ b/src/main/java/com/mulmeong/feed/read/api/presentation/FeedQueryController.java
@@ -1,20 +1,25 @@
 package com.mulmeong.feed.read.api.presentation;
 
 import com.mulmeong.feed.read.api.application.FeedQueryService;
-import com.mulmeong.feed.read.api.dto.FeedResponseDto;
+import com.mulmeong.feed.read.api.dto.in.FeedFilterRequestDto;
+import com.mulmeong.feed.read.api.dto.out.FeedResponseDto;
 import com.mulmeong.feed.read.common.response.BaseResponse;
+import com.mulmeong.feed.read.common.utils.CursorPage;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Feed Query")
 @RequiredArgsConstructor
 @RequestMapping("/v1/feeds")
 @RestController
+@Slf4j
 public class FeedQueryController {
 
     private final FeedQueryService feedQueryService;
@@ -24,6 +29,23 @@ public class FeedQueryController {
     public BaseResponse<FeedResponseDto> getSingleFeed(@PathVariable String feedUuid) {
 
         return new BaseResponse<>(feedQueryService.getSingleFeed(feedUuid));
+    }
+
+    @Operation(summary = "(특정 카테고리 / 특정 해시태그)의 (최신순 / 좋아요순) 피드 목록 조회 API",
+        description = "sortBy: `LATEST` / `LIKES` (대·소문자 구분하지 않음)<br><br>"
+                      + "LATEST: **최신순**, LIKES: **netLikes 내림차순** (likesCount - dislikeCount)")
+    @GetMapping
+    public BaseResponse<CursorPage<FeedResponseDto>> getFeedsByCategoryOrTag(
+        @RequestParam(required = false) String categoryName,
+        @RequestParam(required = false) String hashtagName,
+        @RequestParam(defaultValue = "latest", required = false) String sortBy,
+        @RequestParam(required = false, name = "nextCursor") String lastId,
+        @RequestParam(required = false) Integer pageSize,
+        @RequestParam(required = false) Integer pageNo) {
+
+        return new BaseResponse<>(
+            feedQueryService.getFeedsByCategoryOrTag(FeedFilterRequestDto.toDto(
+                categoryName, hashtagName, sortBy, lastId, pageSize, pageNo)));
     }
 
 }

--- a/src/main/java/com/mulmeong/feed/read/common/config/KafkaConsumerConfig.java
+++ b/src/main/java/com/mulmeong/feed/read/common/config/KafkaConsumerConfig.java
@@ -24,6 +24,9 @@ public class KafkaConsumerConfig {
     @Value("${spring.kafka.bootstrap-servers}")
     private String bootstrapServers;
 
+    @Value("${spring.kafka.consumer.group-id}")
+    private String groupId;
+
     /**
      * 특정 이벤트의 메시지를 소비하는 Kafka Listener 컨테이너 팩토리를 생성.
      *
@@ -63,6 +66,7 @@ public class KafkaConsumerConfig {
     public <T> ConsumerFactory<String, T> consumerFactory(Class<T> messageType) {
         return new DefaultKafkaConsumerFactory<>(Map.of(
             ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers,
+            ConsumerConfig.GROUP_ID_CONFIG, groupId,
             ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class,
             ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class,
             JsonDeserializer.VALUE_DEFAULT_TYPE, messageType.getName(),
@@ -80,6 +84,7 @@ public class KafkaConsumerConfig {
         Class<T> messageType) {
         ConcurrentKafkaListenerContainerFactory<String, T> factory = new ConcurrentKafkaListenerContainerFactory<>();
         factory.setConsumerFactory(consumerFactory(messageType));
+        factory.getContainerProperties().setGroupId(groupId);
         return factory;
     }
 

--- a/src/main/java/com/mulmeong/feed/read/common/config/KafkaConsumerConfig.java
+++ b/src/main/java/com/mulmeong/feed/read/common/config/KafkaConsumerConfig.java
@@ -36,7 +36,6 @@ public class KafkaConsumerConfig {
      * @param messageType 제네릭으로 선언한 Event 객체
      * @return DefaultKafkaConsumerFactory, Kafka Listener가 사용하는 기본 Consumer Factory
      */
-    @Bean
     public <T> ConsumerFactory<String, T> consumerFactory(Class<T> messageType) {
         return new DefaultKafkaConsumerFactory<>(Map.of(
             ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers,
@@ -53,7 +52,6 @@ public class KafkaConsumerConfig {
      * @param messageType 제네릭으로 선언한 Event 객체
      * @return ConcurrentKafkaListenerContainerFactory, 다중 스레드에서 Kafka 메시지를 처리하는 컨테이너 팩토리
      */
-    @Bean
     public <T> ConcurrentKafkaListenerContainerFactory<String, T> kafkaListenerContainerFactory(
         Class<T> messageType) {
         ConcurrentKafkaListenerContainerFactory<String, T> factory = new ConcurrentKafkaListenerContainerFactory<>();

--- a/src/main/java/com/mulmeong/feed/read/common/config/KafkaConsumerConfig.java
+++ b/src/main/java/com/mulmeong/feed/read/common/config/KafkaConsumerConfig.java
@@ -1,6 +1,7 @@
 package com.mulmeong.feed.read.common.config;
 
 import com.mulmeong.feed.read.api.domain.event.FeedCreateEvent;
+import com.mulmeong.feed.read.api.domain.event.FeedDeleteEvent;
 import java.util.Map;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.serialization.StringDeserializer;
@@ -28,6 +29,11 @@ public class KafkaConsumerConfig {
     @Bean
     public ConcurrentKafkaListenerContainerFactory<String, FeedCreateEvent> feedCreateEventListener() {
         return kafkaListenerContainerFactory(FeedCreateEvent.class);
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, FeedDeleteEvent> feedDeleteEventListener() {
+        return kafkaListenerContainerFactory(FeedDeleteEvent.class);
     }
 
     /**

--- a/src/main/java/com/mulmeong/feed/read/common/config/KafkaConsumerConfig.java
+++ b/src/main/java/com/mulmeong/feed/read/common/config/KafkaConsumerConfig.java
@@ -2,6 +2,9 @@ package com.mulmeong.feed.read.common.config;
 
 import com.mulmeong.feed.read.api.domain.event.FeedCreateEvent;
 import com.mulmeong.feed.read.api.domain.event.FeedDeleteEvent;
+import com.mulmeong.feed.read.api.domain.event.FeedHashtagUpdateEvent;
+import com.mulmeong.feed.read.api.domain.event.FeedStatusUpdateEvent;
+import com.mulmeong.feed.read.api.domain.event.FeedUpdateEvent;
 import java.util.Map;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.serialization.StringDeserializer;
@@ -34,6 +37,21 @@ public class KafkaConsumerConfig {
     @Bean
     public ConcurrentKafkaListenerContainerFactory<String, FeedDeleteEvent> feedDeleteEventListener() {
         return kafkaListenerContainerFactory(FeedDeleteEvent.class);
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, FeedHashtagUpdateEvent> feedHashtagUpdateEventListener() {
+        return kafkaListenerContainerFactory(FeedHashtagUpdateEvent.class);
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, FeedStatusUpdateEvent> feedStatusUpdateEventListener() {
+        return kafkaListenerContainerFactory(FeedStatusUpdateEvent.class);
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, FeedUpdateEvent> feedUpdateEventListener() {
+        return kafkaListenerContainerFactory(FeedUpdateEvent.class);
     }
 
     /**

--- a/src/main/java/com/mulmeong/feed/read/common/config/KafkaConsumerConfig.java
+++ b/src/main/java/com/mulmeong/feed/read/common/config/KafkaConsumerConfig.java
@@ -1,0 +1,55 @@
+package com.mulmeong.feed.read.common.config;
+
+import java.util.Map;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+
+@Configuration
+@EnableKafka
+public class KafkaConsumerConfig {
+
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServers;
+
+    // TODO: 이벤트 리스너 정의
+
+    /**
+     * 특정 메시지 타입에 맞게 ConsumerFactory를 생성합니다.
+     *
+     * @param messageType 제네릭으로 선언한 Event 객체
+     * @return DefaultKafkaConsumerFactory, Kafka Listener가 사용하는 기본 Consumer Factory
+     */
+    @Bean
+    public <T> ConsumerFactory<String, T> consumerFactory(Class<T> messageType) {
+        return new DefaultKafkaConsumerFactory<>(Map.of(
+            ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers,
+            ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class,
+            ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class,
+            JsonDeserializer.TRUSTED_PACKAGES, "com.mulmeong.event",
+            JsonDeserializer.VALUE_DEFAULT_TYPE, messageType
+        ));
+    }
+
+    /**
+     * 컨테이너 팩토리는 다중 스레드에서 Kafka 메시지를 처리하며, 이 설정을 통해 KafkaListener가 메시지를 소비합니다.
+     *
+     * @param messageType 제네릭으로 선언한 Event 객체
+     * @return ConcurrentKafkaListenerContainerFactory, 다중 스레드에서 Kafka 메시지를 처리하는 컨테이너 팩토리
+     */
+    @Bean
+    public <T> ConcurrentKafkaListenerContainerFactory<String, T> kafkaListenerContainerFactory(Class<T> messageType) {
+        ConcurrentKafkaListenerContainerFactory<String, T> factory =
+            new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory(messageType));
+        return factory;
+    }
+
+}

--- a/src/main/java/com/mulmeong/feed/read/common/config/SwaggerConfig.java
+++ b/src/main/java/com/mulmeong/feed/read/common/config/SwaggerConfig.java
@@ -37,7 +37,7 @@ public class SwaggerConfig {
         return new Info()
             .title("Qua - FEED QUERY SERVICE API")
             .version("v1")
-            .description("Feed Query Service API Docs: <strong>Read & Write Operations</strong>");
+            .description("Feed Query Service API Docs");
     }
 
 }

--- a/src/main/java/com/mulmeong/feed/read/common/config/SwaggerConfig.java
+++ b/src/main/java/com/mulmeong/feed/read/common/config/SwaggerConfig.java
@@ -1,0 +1,43 @@
+package com.mulmeong.feed.read.common.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    private static final String BEARER_TOKEN_PREFIX = "Bearer";
+
+    @Bean
+    public OpenAPI openApi() {
+
+        String securityJwtName = "JWT";
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList(securityJwtName);
+        Components components = new Components()
+            .addSecuritySchemes(securityJwtName, new SecurityScheme()
+                .name(securityJwtName)
+                .type(SecurityScheme.Type.HTTP)
+                .scheme(BEARER_TOKEN_PREFIX)
+                .bearerFormat(securityJwtName));
+
+        return new OpenAPI()
+            .addSecurityItem(securityRequirement)
+            .components(components)
+            .addServersItem(new Server().url("/feed-read-service"))
+            .info(apiInfo());
+    }
+
+    private Info apiInfo() {
+        return new Info()
+            .title("Qua - FEED QUERY SERVICE API")
+            .version("v1")
+            .description("Feed Query Service API Docs: <strong>Read & Write Operations</strong>");
+    }
+
+}

--- a/src/main/java/com/mulmeong/feed/read/common/exception/BaseException.java
+++ b/src/main/java/com/mulmeong/feed/read/common/exception/BaseException.java
@@ -1,0 +1,14 @@
+package com.mulmeong.feed.read.common.exception;
+
+import com.mulmeong.feed.read.common.response.BaseResponseStatus;
+import lombok.Getter;
+
+@Getter
+public class BaseException extends RuntimeException {
+
+    private final BaseResponseStatus status;
+
+    public BaseException(BaseResponseStatus status) {
+        this.status = status;
+    }
+}

--- a/src/main/java/com/mulmeong/feed/read/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/mulmeong/feed/read/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,49 @@
+package com.mulmeong.feed.read.common.exception;
+
+import static com.mulmeong.feed.read.common.response.BaseResponseStatus.INTERNAL_SERVER_ERROR;
+import static com.mulmeong.feed.read.common.response.BaseResponseStatus.INVALID_INPUT_VALUE;
+
+import com.mulmeong.feed.read.common.response.BaseResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    // 전역 예외 처리 및 JSON 형식의 일관된 에러 응답 제공
+
+    /**
+     * BaseException 예외 처리.
+     */
+    @ExceptionHandler(BaseException.class)
+    protected BaseResponse<Void> baseError(BaseException e) {
+        log.error("BaseException -> {} ({})", e.getStatus(), e.getStatus().getMessage(), e);
+
+        return new BaseResponse<>(e.getStatus());
+    }
+
+    /**
+     * Validation 유효성 검사 실패 예외 처리.
+     */
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    protected BaseResponse<Void> handleValidException(MethodArgumentNotValidException e) {
+        String message = e.getFieldErrors().get(0).getDefaultMessage();
+        log.error("MethodArgumentNotValidException -> {}", message);
+
+        return new BaseResponse<>(INVALID_INPUT_VALUE, message);
+    }
+
+    /**
+     * 예기치 않은 에러. RuntimeException 예외 처리
+     */
+    @ExceptionHandler(RuntimeException.class)
+    protected BaseResponse<Void> runtimeError(RuntimeException e) {
+        log.error("RuntimeException -> {}", e.getMessage(), e);
+
+        return new BaseResponse<>(INTERNAL_SERVER_ERROR, e.getMessage());
+    }
+
+}

--- a/src/main/java/com/mulmeong/feed/read/common/health/HealthCheckController.java
+++ b/src/main/java/com/mulmeong/feed/read/common/health/HealthCheckController.java
@@ -1,0 +1,20 @@
+package com.mulmeong.feed.read.common.health;
+
+import static org.springframework.http.HttpStatus.OK;
+
+import io.swagger.v3.oas.annotations.Hidden;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Hidden
+@RestController
+public class HealthCheckController {
+
+    @GetMapping("/health-check")
+    public ResponseEntity<Void> checkHealthStatus() {
+
+        return new ResponseEntity<>(OK);
+    }
+
+}

--- a/src/main/java/com/mulmeong/feed/read/common/response/BaseResponse.java
+++ b/src/main/java/com/mulmeong/feed/read/common/response/BaseResponse.java
@@ -1,0 +1,52 @@
+package com.mulmeong.feed.read.common.response;
+
+import com.mulmeong.feed.read.common.utils.TypeCaster;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+
+import static com.mulmeong.feed.read.common.response.BaseResponseStatus.SUCCESS;
+
+public record BaseResponse<T>(HttpStatusCode httpStatus, Boolean isSuccess, String message,
+                              int code, T result) {
+
+    // 필요값 : Http 상태코드, 성공여부, 메시지, 에러코드, 결과값
+
+    /**
+     * 1. Return 객체가 필요한 경우 -> 성공
+     *
+     * @param result 반환해야 하는 결과 객체
+     */
+    public BaseResponse(T result) {
+        this(HttpStatus.OK, true, SUCCESS.getMessage(), SUCCESS.getCode(), result);
+    }
+
+    /**
+     * 2. Return 객체가 필요 없는 경우 -> 성공
+     */
+
+    public BaseResponse() {
+        this(HttpStatus.OK, true, SUCCESS.getMessage(), SUCCESS.getCode(), null);
+    }
+
+    /**
+     * 3. 요청에 실패한 경우
+     *
+     * @param status 응답 상태
+     */
+    public BaseResponse(BaseResponseStatus status) {
+        this(status.getHttpStatusCode(), false, status.getMessage(), status.getCode(),
+            TypeCaster.castMessage(status.getMessage()));
+    }
+
+    /**
+     * 4. 요청에 실패한 경우
+     *
+     * @param status 응답 상태
+     * @param message 에러 메시지
+     */
+    public BaseResponse(BaseResponseStatus status, String message) {
+        this(status.getHttpStatusCode(), false, message, status.getCode(),
+            TypeCaster.castMessage(status.getMessage()));
+    }
+
+}

--- a/src/main/java/com/mulmeong/feed/read/common/response/BaseResponseStatus.java
+++ b/src/main/java/com/mulmeong/feed/read/common/response/BaseResponseStatus.java
@@ -1,0 +1,39 @@
+package com.mulmeong.feed.read.common.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+
+@Getter
+@AllArgsConstructor
+public enum BaseResponseStatus {
+
+    /**
+     * 200: 요청 성공.
+     **/
+    SUCCESS(HttpStatus.OK, true, 200, "요청에 성공하였습니다."),
+
+    /**
+     * 400: 사용자 요청 에러.
+     */
+    ILLEGAL_ARGUMENT(HttpStatus.BAD_REQUEST, false, 400, "잘못된 요청입니다."),
+    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, false, 401, "적절하지 않은 요청값입니다."),
+
+    /**
+     * 900: 기타 에러.
+     */
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, false, 900, "서버에서 예기치 않은 오류가 발생했습니다."),
+
+    /**
+     * 1000: Feed Service 에러.
+     */
+    FEED_FORBIDDEN(HttpStatus.FORBIDDEN, false, 1003, "피드 접근 권한이 없습니다."),
+    FEED_NOT_FOUND(HttpStatus.NOT_FOUND, false, 1004, "존재하지 않는 게시글 정보입니다.");
+
+    private final HttpStatusCode httpStatusCode;
+    private final boolean isSuccess;
+    private final int code;
+    private final String message;
+
+}

--- a/src/main/java/com/mulmeong/feed/read/common/utils/CursorPage.java
+++ b/src/main/java/com/mulmeong/feed/read/common/utils/CursorPage.java
@@ -1,0 +1,36 @@
+package com.mulmeong.feed.read.common.utils;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class CursorPage<T> {
+
+    private List<T> content;
+    private String nextCursor;
+    private Boolean hasNext;
+    private Integer pageSize;
+    private Integer pageNo;
+
+    public static <T, U> CursorPage<T> toCursorPage(CursorPage<U> cursorPage, List<T> content) {
+
+        return CursorPage.<T>builder()
+            .content(content)
+            .nextCursor(cursorPage.getNextCursor())
+            .hasNext(cursorPage.getHasNext())
+            .pageSize(cursorPage.getPageSize())
+            .pageNo(cursorPage.getPageNo())
+            .build();
+    }
+
+    @Builder
+    public CursorPage(List<T> content, String nextCursor, Boolean hasNext, Integer pageSize,
+        Integer pageNo) {
+        this.content = content;
+        this.nextCursor = nextCursor;
+        this.hasNext = hasNext;
+        this.pageSize = pageSize;
+        this.pageNo = pageNo;
+    }
+}

--- a/src/main/java/com/mulmeong/feed/read/common/utils/TypeCaster.java
+++ b/src/main/java/com/mulmeong/feed/read/common/utils/TypeCaster.java
@@ -1,0 +1,14 @@
+package com.mulmeong.feed.read.common.utils;
+
+public class TypeCaster {
+
+    @SuppressWarnings("unchecked")
+    public static <T> T castMessage(Object message) {
+        try {
+            return (T) message;
+        } catch (ClassCastException e) {
+            return null;
+        }
+    }
+
+}


### PR DESCRIPTION
<!-- Title: [🚀 (Service名)] (AAA) 기능 구현 -->
<!-- Merge 방향 및 Branch 확인해주세요 -->
<!-- (괄호) 부분은 다 지우고 작성해주세요 -->

### 📅 2024.12.02

### 🌵 Branch
develop → release

### 📢 Description
- 초기 설정 파일 생성 (Config-server yml, Gateway yml, Swagger Config, Kafka Consumer Config, GlobalExceptionHanlder ... )
- Config Server 연동<br><br>

- (_특정 카테고리 / 특정 해시태그_)의 (_최신순 / 좋아요순_) 피드 목록 조회 API 구현: Visibility = `VISIBLE`인 Feed만을 조회
- **특정 사용자가 작성한 피드 목록 조회 API 구현**: 요청자와 작성자의 memberUuid가 같으면 조건에 맞는 모든 Feed를, 같지 않으면 Visibility = `VISIBLE`인 Feed만을 조회

이하 Pull Request 및 Issue 내용 참고

### 📦 Pull Request Number
- #4 

### 💬 Issue Number
- #3 

### 🔖 Note
**Pagination**을 베이스로 하는 필터링 구현