### PR TITLE
[🔀 Feed-Read] 특정 사용자가 작성한 피드 목록 조회 API 분리

### DIFF
--- a/src/main/java/com/mulmeong/feed/read/api/application/FeedQueryServiceImpl.java
+++ b/src/main/java/com/mulmeong/feed/read/api/application/FeedQueryServiceImpl.java
@@ -13,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 @Service
 public class FeedQueryServiceImpl implements FeedQueryService {
@@ -20,7 +21,6 @@ public class FeedQueryServiceImpl implements FeedQueryService {
     private final FeedQueryRepository feedQueryRepository;
     private final FeedCustomRepository feedCustomRepository;
 
-    @Transactional(readOnly = true)
     @Override
     public FeedResponseDto getSingleFeed(String feedUuid) {
 
@@ -28,14 +28,12 @@ public class FeedQueryServiceImpl implements FeedQueryService {
             .orElseThrow(() -> new BaseException(FEED_NOT_FOUND)));
     }
 
-    @Transactional(readOnly = true)
     @Override
     public CursorPage<FeedResponseDto> getFeedsByCategoryOrTag(FeedFilterRequestDto requestDto) {
 
         return feedCustomRepository.getFeedsByCategoryOrTag(requestDto);
     }
 
-    @Transactional(readOnly = true)
     @Override
     public CursorPage<FeedResponseDto> getFeedsByAuthor(FeedAuthorRequestDto requestDto) {
 

--- a/src/main/java/com/mulmeong/feed/read/api/dto/in/FeedAuthorRequestDto.java
+++ b/src/main/java/com/mulmeong/feed/read/api/dto/in/FeedAuthorRequestDto.java
@@ -9,14 +9,14 @@ import lombok.Getter;
 public class FeedAuthorRequestDto extends BasePaginationRequestDto {
 
     private String authorUuid;
-    private String requesterUuid;
+    private boolean isOwner;
 
-    public static FeedAuthorRequestDto toDto(String authorUuid, String requesterUuid, String sortBy,
+    public static FeedAuthorRequestDto toDto(String authorUuid, boolean isOwner, String sortBy,
         String lastId, Integer pageSize, Integer pageNo) {
 
         return FeedAuthorRequestDto.builder()
             .authorUuid(authorUuid)
-            .requesterUuid(requesterUuid)
+            .isOwner(isOwner)
             .sortType(SortType.valueOf(sortBy.toUpperCase()))
             .lastId(lastId)
             .pageSize(pageSize)
@@ -25,12 +25,12 @@ public class FeedAuthorRequestDto extends BasePaginationRequestDto {
     }
 
     @Builder
-    public FeedAuthorRequestDto(String authorUuid, String requesterUuid, SortType sortType,
+    public FeedAuthorRequestDto(String authorUuid, boolean isOwner, SortType sortType,
         String lastId, Integer pageSize, Integer pageNo) {
 
         super(sortType, lastId, pageSize, pageNo);
         this.authorUuid = authorUuid;
-        this.requesterUuid = requesterUuid;
+        this.isOwner = isOwner;
     }
 
 }

--- a/src/main/java/com/mulmeong/feed/read/api/infrastructure/FeedCustomRepository.java
+++ b/src/main/java/com/mulmeong/feed/read/api/infrastructure/FeedCustomRepository.java
@@ -46,7 +46,7 @@ public class FeedCustomRepository {     // QueryDSL Repository
 
         BooleanBuilder builder = new BooleanBuilder();
 
-        if (!requestDto.getRequesterUuid().equals(requestDto.getAuthorUuid())) {
+        if (!requestDto.isOwner()) {
             builder.and(feed.visibility.eq(Visibility.VISIBLE));
         }
         Optional.ofNullable(requestDto.getAuthorUuid()).ifPresent(author ->

--- a/src/main/java/com/mulmeong/feed/read/api/presentation/AuthRequiredFeedQueryController.java
+++ b/src/main/java/com/mulmeong/feed/read/api/presentation/AuthRequiredFeedQueryController.java
@@ -23,22 +23,20 @@ public class AuthRequiredFeedQueryController {
 
     private final FeedQueryService feedQueryService;
 
-    @Operation(summary = "특정 사용자가 작성한 피드 목록 조회",
+    @Operation(summary = "특정 사용자가 작성한 피드 목록 조회 (프로필 페이지의 Owner가 요청시)",
         description = """
-            - **요청자와 작성자의 memberUuid가 같으면** 조건에 맞는 모든 Feed를,
-            같지 않으면 Visibility = `VISIBLE`인 Feed만을 조회<br><br>
+            - 조건에 부합하는 모든 Feed를 조회<br><br>
             - sortBy: `LATEST` / `LIKES` (대·소문자 구분하지 않음)<br><br>
             - LATEST: **최신순**, LIKES: **netLikes 내림차순** (likesCount - dislikeCount)""")
     @GetMapping("/{memberUuid}/feeds")
     public BaseResponse<CursorPage<FeedResponseDto>> getFeedsByAuthor(
         @PathVariable(name = "memberUuid") String authorUuid,
-        @RequestHeader("Member-Uuid") String requesterUuid,
         @RequestParam(defaultValue = "latest", required = false) String sortBy,
         @RequestParam(required = false, name = "nextCursor") String lastId,
         @RequestParam(required = false) Integer pageSize,
         @RequestParam(required = false) Integer pageNo) {
 
         return new BaseResponse<>(feedQueryService.getFeedsByAuthor(FeedAuthorRequestDto.toDto(
-            authorUuid, requesterUuid, sortBy, lastId, pageSize, pageNo)));
+            authorUuid, true, sortBy, lastId, pageSize, pageNo)));
     }
 }

--- a/src/main/java/com/mulmeong/feed/read/api/presentation/FeedQueryController.java
+++ b/src/main/java/com/mulmeong/feed/read/api/presentation/FeedQueryController.java
@@ -1,6 +1,7 @@
 package com.mulmeong.feed.read.api.presentation;
 
 import com.mulmeong.feed.read.api.application.FeedQueryService;
+import com.mulmeong.feed.read.api.dto.in.FeedAuthorRequestDto;
 import com.mulmeong.feed.read.api.dto.in.FeedFilterRequestDto;
 import com.mulmeong.feed.read.api.dto.out.FeedResponseDto;
 import com.mulmeong.feed.read.common.response.BaseResponse;
@@ -17,7 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Feed Query")
 @RequiredArgsConstructor
-@RequestMapping("/v1/feeds")
+@RequestMapping("/v1")
 @RestController
 @Slf4j
 public class FeedQueryController {
@@ -29,7 +30,7 @@ public class FeedQueryController {
         - MediaType: `IMAGE` / `VIDEO`<br>
         - MediaSubType: `IMAGE` / `VIDEO_THUMBNAIL` / `VIDEO_360` / `VIDEO_540` / `VIDEO_720` / `VIDEO_MP4`<br><br>
         - FeedMedia 테이블은 **FE에서 생성한 MediaUUID를 기본키로 설정**하는 것에 주의""")
-    @GetMapping("/{feedUuid}")
+    @GetMapping("/feeds/{feedUuid}")
     public BaseResponse<FeedResponseDto> getSingleFeed(@PathVariable String feedUuid) {
 
         return new BaseResponse<>(feedQueryService.getSingleFeed(feedUuid));
@@ -40,7 +41,7 @@ public class FeedQueryController {
             - sortBy: `LATEST` / `LIKES` (대·소문자 구분하지 않음)<br><br>
             - LATEST: **최신순**, LIKES: **netLikes 내림차순** (likesCount - dislikeCount)<br><br>
             - Visibility: `VISIBLE`인 피드 목록만 조회""")
-    @GetMapping
+    @GetMapping("/feeds")
     public BaseResponse<CursorPage<FeedResponseDto>> getFeedsByCategoryOrTag(
         @RequestParam(required = false) String categoryName,
         @RequestParam(required = false) String hashtagName,
@@ -52,6 +53,23 @@ public class FeedQueryController {
         return new BaseResponse<>(
             feedQueryService.getFeedsByCategoryOrTag(FeedFilterRequestDto.toDto(
                 categoryName, hashtagName, sortBy, lastId, pageSize, pageNo)));
+    }
+
+    @Operation(summary = "특정 사용자가 작성한 피드 목록 조회 (Guest가 요청시)",
+        description = """
+            - 조건에 부합하는 모든 Feed를 조회<br><br>
+            - sortBy: `LATEST` / `LIKES` (대·소문자 구분하지 않음)<br><br>
+            - LATEST: **최신순**, LIKES: **netLikes 내림차순** (likesCount - dislikeCount)""")
+    @GetMapping("/members/{memberUuid}/feeds")
+    public BaseResponse<CursorPage<FeedResponseDto>> getFeedsByAuthor(
+        @PathVariable(name = "memberUuid") String authorUuid,
+        @RequestParam(defaultValue = "latest", required = false) String sortBy,
+        @RequestParam(required = false, name = "nextCursor") String lastId,
+        @RequestParam(required = false) Integer pageSize,
+        @RequestParam(required = false) Integer pageNo) {
+
+        return new BaseResponse<>(feedQueryService.getFeedsByAuthor(FeedAuthorRequestDto.toDto(
+            authorUuid, false, sortBy, lastId, pageSize, pageNo)));
     }
 
 }


### PR DESCRIPTION
<!-- Title: [🔀 (Service名)] (AAA) 기능 구현 -->
<!-- Merge 방향 및 Branch 확인해주세요 -->
<!-- (괄호) 부분은 다 지우고 작성해주세요 -->

### 📅 2024.12.09 ~ 2024.12.09

### 🌵 Branch
refactor/feed-read/#9 → develop

### 📢 Description
프로필 페이지에서 **요청자가 Owner인지 Guest인지에 따라** 특정 사용자가 작성한 피드 목록 조회 API 분리

### 💬 Issue Number
- #9 

### ✔️ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 코드가 정상적으로 동작하는지 테스트 했습니다.

### 🔖 Note
- Guest가 요청시: Visibility = `VISIBLE`인 Feed만을 조회
- Owner가 요청시: 조건에 부합하는 모든 Feed를 조회