### PR TITLE
[🔀 Feed-Read] 랜덤 해시태그 조회 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,7 @@ ext {
 dependencies {
 	// Spring Boot Starter
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 
 	// Spring Cloud Config
@@ -51,6 +52,7 @@ dependencies {
 	implementation 'org.springframework.kafka:spring-kafka'
 
 	// Database
+	runtimeOnly 'com.mysql:mysql-connector-j'
 	implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
 
 	// QueryDSL

--- a/src/main/java/com/mulmeong/feed/read/api/application/FeedQueryService.java
+++ b/src/main/java/com/mulmeong/feed/read/api/application/FeedQueryService.java
@@ -1,9 +1,11 @@
 package com.mulmeong.feed.read.api.application;
 
+import com.mulmeong.feed.read.api.domain.model.Hashtag;
 import com.mulmeong.feed.read.api.dto.in.FeedAuthorRequestDto;
 import com.mulmeong.feed.read.api.dto.in.FeedFilterRequestDto;
 import com.mulmeong.feed.read.api.dto.out.FeedResponseDto;
 import com.mulmeong.feed.read.common.utils.CursorPage;
+import java.util.List;
 
 public interface FeedQueryService {
 
@@ -12,5 +14,7 @@ public interface FeedQueryService {
     CursorPage<FeedResponseDto> getFeedsByCategoryOrTag(FeedFilterRequestDto requestDto);
 
     CursorPage<FeedResponseDto> getFeedsByAuthor(FeedAuthorRequestDto requestDto);
+
+    List<Hashtag> getFeedHashtags(int size);
 
 }

--- a/src/main/java/com/mulmeong/feed/read/api/application/FeedQueryServiceImpl.java
+++ b/src/main/java/com/mulmeong/feed/read/api/application/FeedQueryServiceImpl.java
@@ -2,13 +2,16 @@ package com.mulmeong.feed.read.api.application;
 
 import static com.mulmeong.feed.read.common.response.BaseResponseStatus.FEED_NOT_FOUND;
 
+import com.mulmeong.feed.read.api.domain.model.Hashtag;
 import com.mulmeong.feed.read.api.dto.in.FeedAuthorRequestDto;
 import com.mulmeong.feed.read.api.dto.in.FeedFilterRequestDto;
 import com.mulmeong.feed.read.api.dto.out.FeedResponseDto;
 import com.mulmeong.feed.read.api.infrastructure.FeedCustomRepository;
 import com.mulmeong.feed.read.api.infrastructure.FeedQueryRepository;
+import com.mulmeong.feed.read.api.infrastructure.HashtagQueryRepository;
 import com.mulmeong.feed.read.common.exception.BaseException;
 import com.mulmeong.feed.read.common.utils.CursorPage;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,6 +23,7 @@ public class FeedQueryServiceImpl implements FeedQueryService {
 
     private final FeedQueryRepository feedQueryRepository;
     private final FeedCustomRepository feedCustomRepository;
+    private final HashtagQueryRepository hashtagQueryRepository;
 
     @Override
     public FeedResponseDto getSingleFeed(String feedUuid) {
@@ -38,6 +42,13 @@ public class FeedQueryServiceImpl implements FeedQueryService {
     public CursorPage<FeedResponseDto> getFeedsByAuthor(FeedAuthorRequestDto requestDto) {
 
         return feedCustomRepository.getFeedsByAuthor(requestDto);
+    }
+
+    @Override
+    public List<Hashtag> getFeedHashtags(int size) {
+
+        return hashtagQueryRepository.getFeedHashtags(size).stream()
+            .map(feedHashtag -> new Hashtag(feedHashtag.getName())).toList();
     }
 
 }

--- a/src/main/java/com/mulmeong/feed/read/api/domain/entity/FeedHashtag.java
+++ b/src/main/java/com/mulmeong/feed/read/api/domain/entity/FeedHashtag.java
@@ -1,0 +1,29 @@
+package com.mulmeong.feed.read.api.domain.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Entity(name = "hashtag")
+public class FeedHashtag {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true, length = 20)
+    private String name;
+
+    @Builder
+    public FeedHashtag(Long id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+}

--- a/src/main/java/com/mulmeong/feed/read/api/domain/event/FeedCreateEvent.java
+++ b/src/main/java/com/mulmeong/feed/read/api/domain/event/FeedCreateEvent.java
@@ -1,6 +1,7 @@
 package com.mulmeong.feed.read.api.domain.event;
 
 import com.mulmeong.feed.read.api.domain.document.Feed;
+import com.mulmeong.feed.read.api.domain.entity.FeedHashtag;
 import com.mulmeong.feed.read.api.domain.model.Hashtag;
 import com.mulmeong.feed.read.api.domain.model.Media;
 import com.mulmeong.feed.read.api.domain.model.Visibility;
@@ -24,7 +25,7 @@ public class FeedCreateEvent {
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 
-    public Feed toDocument() {
+    public Feed toFeedDocument() {
         return Feed.builder()
             .feedUuid(feedUuid)
             .memberUuid(memberUuid)
@@ -41,6 +42,14 @@ public class FeedCreateEvent {
             .createdAt(createdAt)
             .updatedAt(updatedAt)
             .build();
+    }
+
+    public List<FeedHashtag> toHashtagEntities() {
+        return hashtags.stream()
+            .map(hashtag -> FeedHashtag.builder()
+                .name(hashtag.getName())
+                .build())
+            .toList();
     }
 
 }

--- a/src/main/java/com/mulmeong/feed/read/api/infrastructure/HashtagEventRepository.java
+++ b/src/main/java/com/mulmeong/feed/read/api/infrastructure/HashtagEventRepository.java
@@ -1,0 +1,8 @@
+package com.mulmeong.feed.read.api.infrastructure;
+
+import com.mulmeong.feed.read.api.domain.entity.FeedHashtag;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface HashtagEventRepository extends JpaRepository<FeedHashtag, Long> {
+
+}

--- a/src/main/java/com/mulmeong/feed/read/api/infrastructure/HashtagQueryRepository.java
+++ b/src/main/java/com/mulmeong/feed/read/api/infrastructure/HashtagQueryRepository.java
@@ -1,0 +1,13 @@
+package com.mulmeong.feed.read.api.infrastructure;
+
+import com.mulmeong.feed.read.api.domain.entity.FeedHashtag;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface HashtagQueryRepository extends JpaRepository<FeedHashtag, Long> {
+
+    @Query(value = "SELECT * FROM hashtag ORDER BY RAND() LIMIT :size", nativeQuery = true)
+    List<FeedHashtag> getFeedHashtags(int size);
+
+}

--- a/src/main/java/com/mulmeong/feed/read/api/presentation/AuthRequiredFeedQueryController.java
+++ b/src/main/java/com/mulmeong/feed/read/api/presentation/AuthRequiredFeedQueryController.java
@@ -23,7 +23,7 @@ public class AuthRequiredFeedQueryController {
 
     private final FeedQueryService feedQueryService;
 
-    @Operation(summary = "특정 사용자가 작성한 피드 목록 조회 (프로필 페이지의 Owner가 요청시)",
+    @Operation(summary = "특정 사용자가 작성한 피드 목록 조회 API (프로필 페이지의 Owner가 요청시)",
         description = """
             - 조건에 부합하는 모든 Feed를 조회<br><br>
             - sortBy: `LATEST` / `LIKES` (대·소문자 구분하지 않음)<br><br>

--- a/src/main/java/com/mulmeong/feed/read/api/presentation/FeedQueryController.java
+++ b/src/main/java/com/mulmeong/feed/read/api/presentation/FeedQueryController.java
@@ -1,6 +1,7 @@
 package com.mulmeong.feed.read.api.presentation;
 
 import com.mulmeong.feed.read.api.application.FeedQueryService;
+import com.mulmeong.feed.read.api.domain.model.Hashtag;
 import com.mulmeong.feed.read.api.dto.in.FeedAuthorRequestDto;
 import com.mulmeong.feed.read.api.dto.in.FeedFilterRequestDto;
 import com.mulmeong.feed.read.api.dto.out.FeedResponseDto;
@@ -8,6 +9,7 @@ import com.mulmeong.feed.read.common.response.BaseResponse;
 import com.mulmeong.feed.read.common.utils.CursorPage;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -55,7 +57,7 @@ public class FeedQueryController {
                 categoryName, hashtagName, sortBy, lastId, pageSize, pageNo)));
     }
 
-    @Operation(summary = "특정 사용자가 작성한 피드 목록 조회 (Guest가 요청시)",
+    @Operation(summary = "특정 사용자가 작성한 피드 목록 조회 API (Guest가 요청시)",
         description = """
             - Visibility = `VISIBLE`인 Feed만을 조회<br><br>
             - sortBy: `LATEST` / `LIKES` (대·소문자 구분하지 않음)<br><br>
@@ -70,6 +72,17 @@ public class FeedQueryController {
 
         return new BaseResponse<>(feedQueryService.getFeedsByAuthor(FeedAuthorRequestDto.toDto(
             authorUuid, false, sortBy, lastId, pageSize, pageNo)));
+    }
+
+    @Operation(summary = "랜덤 해시태그 목록 조회 API",
+        description = """
+                      (추후 계획: 유저 관심 태그와 유사한 해시태그 조회 API로 수정 예정)<br><br>
+                      - Size default: **30**""")
+    @GetMapping("/hashtags")
+    public BaseResponse<List<Hashtag>> getFeedHashtags(
+        @RequestParam(required = false, defaultValue = "30") Integer size) {
+
+        return new BaseResponse<>(feedQueryService.getFeedHashtags(size));
     }
 
 }

--- a/src/main/java/com/mulmeong/feed/read/api/presentation/FeedQueryController.java
+++ b/src/main/java/com/mulmeong/feed/read/api/presentation/FeedQueryController.java
@@ -57,7 +57,7 @@ public class FeedQueryController {
 
     @Operation(summary = "특정 사용자가 작성한 피드 목록 조회 (Guest가 요청시)",
         description = """
-            - 조건에 부합하는 모든 Feed를 조회<br><br>
+            - Visibility = `VISIBLE`인 Feed만을 조회<br><br>
             - sortBy: `LATEST` / `LIKES` (대·소문자 구분하지 않음)<br><br>
             - LATEST: **최신순**, LIKES: **netLikes 내림차순** (likesCount - dislikeCount)""")
     @GetMapping("/members/{memberUuid}/feeds")

--- a/src/main/java/com/mulmeong/feed/read/common/response/BaseResponseStatus.java
+++ b/src/main/java/com/mulmeong/feed/read/common/response/BaseResponseStatus.java
@@ -29,7 +29,8 @@ public enum BaseResponseStatus {
      * 1000: Feed Service 에러.
      */
     FEED_FORBIDDEN(HttpStatus.FORBIDDEN, false, 1003, "피드 접근 권한이 없습니다."),
-    FEED_NOT_FOUND(HttpStatus.NOT_FOUND, false, 1004, "존재하지 않는 게시글 정보입니다.");
+    FEED_NOT_FOUND(HttpStatus.NOT_FOUND, false, 1004, "존재하지 않는 게시글 정보입니다."),
+    HASHTAG_DUPLICATE_KEY(HttpStatus.CONFLICT, false, 1009, "해시태그가 이미 존재합니다.");
 
     private final HttpStatusCode httpStatusCode;
     private final boolean isSuccess;


### PR DESCRIPTION
<!-- Title: [🔀 (Service名)] (AAA) 기능 구현 -->
<!-- Merge 방향 및 Branch 확인해주세요 -->
<!-- (괄호) 부분은 다 지우고 작성해주세요 -->

### 📅 2024.12.11 ~ 2024.12.11

### 🌵 Branch
feature/feed-read/#11 → develop

### 📢 Description
랜덤 해시태그 조회 API 구현 & Hashtag Create Event Handling

### 💬 Issue Number
- #11 

### ✔️ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 코드가 정상적으로 동작하는지 테스트 했습니다.

### 🔖 Note
- 임시로 구현해놓고 추후 인기 해시태그 조회 API로 수정 예정
- Hashtag명의 무결성 체크가 간편한 RDB 채택
- 사이드바에서의 해시태그 목록 조회에 활용 (정책상 Feed 해시태그만을 조회하는 페이지)