### PR TITLE
[🚀 Feed-Read] 특정 사용자가 작성한 피드 목록 조회 API 분리 및 해시태그 조회 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,7 @@ ext {
 dependencies {
 	// Spring Boot Starter
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 
 	// Spring Cloud Config
@@ -51,6 +52,7 @@ dependencies {
 	implementation 'org.springframework.kafka:spring-kafka'
 
 	// Database
+	runtimeOnly 'com.mysql:mysql-connector-j'
 	implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
 
 	// QueryDSL

--- a/src/main/java/com/mulmeong/feed/read/api/application/FeedQueryService.java
+++ b/src/main/java/com/mulmeong/feed/read/api/application/FeedQueryService.java
@@ -1,9 +1,11 @@
 package com.mulmeong.feed.read.api.application;
 
+import com.mulmeong.feed.read.api.domain.model.Hashtag;
 import com.mulmeong.feed.read.api.dto.in.FeedAuthorRequestDto;
 import com.mulmeong.feed.read.api.dto.in.FeedFilterRequestDto;
 import com.mulmeong.feed.read.api.dto.out.FeedResponseDto;
 import com.mulmeong.feed.read.common.utils.CursorPage;
+import java.util.List;
 
 public interface FeedQueryService {
 
@@ -12,5 +14,7 @@ public interface FeedQueryService {
     CursorPage<FeedResponseDto> getFeedsByCategoryOrTag(FeedFilterRequestDto requestDto);
 
     CursorPage<FeedResponseDto> getFeedsByAuthor(FeedAuthorRequestDto requestDto);
+
+    List<Hashtag> getFeedHashtags(int size);
 
 }

--- a/src/main/java/com/mulmeong/feed/read/api/application/FeedQueryServiceImpl.java
+++ b/src/main/java/com/mulmeong/feed/read/api/application/FeedQueryServiceImpl.java
@@ -13,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 @Service
 public class FeedQueryServiceImpl implements FeedQueryService {
@@ -20,7 +21,6 @@ public class FeedQueryServiceImpl implements FeedQueryService {
     private final FeedQueryRepository feedQueryRepository;
     private final FeedCustomRepository feedCustomRepository;
 
-    @Transactional(readOnly = true)
     @Override
     public FeedResponseDto getSingleFeed(String feedUuid) {
 
@@ -28,14 +28,12 @@ public class FeedQueryServiceImpl implements FeedQueryService {
             .orElseThrow(() -> new BaseException(FEED_NOT_FOUND)));
     }
 
-    @Transactional(readOnly = true)
     @Override
     public CursorPage<FeedResponseDto> getFeedsByCategoryOrTag(FeedFilterRequestDto requestDto) {
 
         return feedCustomRepository.getFeedsByCategoryOrTag(requestDto);
     }
 
-    @Transactional(readOnly = true)
     @Override
     public CursorPage<FeedResponseDto> getFeedsByAuthor(FeedAuthorRequestDto requestDto) {
 

--- a/src/main/java/com/mulmeong/feed/read/api/application/FeedQueryServiceImpl.java
+++ b/src/main/java/com/mulmeong/feed/read/api/application/FeedQueryServiceImpl.java
@@ -2,13 +2,16 @@ package com.mulmeong.feed.read.api.application;
 
 import static com.mulmeong.feed.read.common.response.BaseResponseStatus.FEED_NOT_FOUND;
 
+import com.mulmeong.feed.read.api.domain.model.Hashtag;
 import com.mulmeong.feed.read.api.dto.in.FeedAuthorRequestDto;
 import com.mulmeong.feed.read.api.dto.in.FeedFilterRequestDto;
 import com.mulmeong.feed.read.api.dto.out.FeedResponseDto;
 import com.mulmeong.feed.read.api.infrastructure.FeedCustomRepository;
 import com.mulmeong.feed.read.api.infrastructure.FeedQueryRepository;
+import com.mulmeong.feed.read.api.infrastructure.HashtagQueryRepository;
 import com.mulmeong.feed.read.common.exception.BaseException;
 import com.mulmeong.feed.read.common.utils.CursorPage;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,6 +23,7 @@ public class FeedQueryServiceImpl implements FeedQueryService {
 
     private final FeedQueryRepository feedQueryRepository;
     private final FeedCustomRepository feedCustomRepository;
+    private final HashtagQueryRepository hashtagQueryRepository;
 
     @Override
     public FeedResponseDto getSingleFeed(String feedUuid) {
@@ -38,6 +42,13 @@ public class FeedQueryServiceImpl implements FeedQueryService {
     public CursorPage<FeedResponseDto> getFeedsByAuthor(FeedAuthorRequestDto requestDto) {
 
         return feedCustomRepository.getFeedsByAuthor(requestDto);
+    }
+
+    @Override
+    public List<Hashtag> getFeedHashtags(int size) {
+
+        return hashtagQueryRepository.getFeedHashtags(size).stream()
+            .map(feedHashtag -> new Hashtag(feedHashtag.getName())).toList();
     }
 
 }

--- a/src/main/java/com/mulmeong/feed/read/api/domain/entity/FeedHashtag.java
+++ b/src/main/java/com/mulmeong/feed/read/api/domain/entity/FeedHashtag.java
@@ -1,0 +1,29 @@
+package com.mulmeong.feed.read.api.domain.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Entity(name = "hashtag")
+public class FeedHashtag {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true, length = 20)
+    private String name;
+
+    @Builder
+    public FeedHashtag(Long id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+}

--- a/src/main/java/com/mulmeong/feed/read/api/domain/event/FeedCreateEvent.java
+++ b/src/main/java/com/mulmeong/feed/read/api/domain/event/FeedCreateEvent.java
@@ -1,6 +1,7 @@
 package com.mulmeong.feed.read.api.domain.event;
 
 import com.mulmeong.feed.read.api.domain.document.Feed;
+import com.mulmeong.feed.read.api.domain.entity.FeedHashtag;
 import com.mulmeong.feed.read.api.domain.model.Hashtag;
 import com.mulmeong.feed.read.api.domain.model.Media;
 import com.mulmeong.feed.read.api.domain.model.Visibility;
@@ -24,7 +25,7 @@ public class FeedCreateEvent {
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 
-    public Feed toDocument() {
+    public Feed toFeedDocument() {
         return Feed.builder()
             .feedUuid(feedUuid)
             .memberUuid(memberUuid)
@@ -41,6 +42,14 @@ public class FeedCreateEvent {
             .createdAt(createdAt)
             .updatedAt(updatedAt)
             .build();
+    }
+
+    public List<FeedHashtag> toHashtagEntities() {
+        return hashtags.stream()
+            .map(hashtag -> FeedHashtag.builder()
+                .name(hashtag.getName())
+                .build())
+            .toList();
     }
 
 }

--- a/src/main/java/com/mulmeong/feed/read/api/dto/in/FeedAuthorRequestDto.java
+++ b/src/main/java/com/mulmeong/feed/read/api/dto/in/FeedAuthorRequestDto.java
@@ -9,14 +9,14 @@ import lombok.Getter;
 public class FeedAuthorRequestDto extends BasePaginationRequestDto {
 
     private String authorUuid;
-    private String requesterUuid;
+    private boolean isOwner;
 
-    public static FeedAuthorRequestDto toDto(String authorUuid, String requesterUuid, String sortBy,
+    public static FeedAuthorRequestDto toDto(String authorUuid, boolean isOwner, String sortBy,
         String lastId, Integer pageSize, Integer pageNo) {
 
         return FeedAuthorRequestDto.builder()
             .authorUuid(authorUuid)
-            .requesterUuid(requesterUuid)
+            .isOwner(isOwner)
             .sortType(SortType.valueOf(sortBy.toUpperCase()))
             .lastId(lastId)
             .pageSize(pageSize)
@@ -25,12 +25,12 @@ public class FeedAuthorRequestDto extends BasePaginationRequestDto {
     }
 
     @Builder
-    public FeedAuthorRequestDto(String authorUuid, String requesterUuid, SortType sortType,
+    public FeedAuthorRequestDto(String authorUuid, boolean isOwner, SortType sortType,
         String lastId, Integer pageSize, Integer pageNo) {
 
         super(sortType, lastId, pageSize, pageNo);
         this.authorUuid = authorUuid;
-        this.requesterUuid = requesterUuid;
+        this.isOwner = isOwner;
     }
 
 }

--- a/src/main/java/com/mulmeong/feed/read/api/infrastructure/FeedCustomRepository.java
+++ b/src/main/java/com/mulmeong/feed/read/api/infrastructure/FeedCustomRepository.java
@@ -46,7 +46,7 @@ public class FeedCustomRepository {     // QueryDSL Repository
 
         BooleanBuilder builder = new BooleanBuilder();
 
-        if (!requestDto.getRequesterUuid().equals(requestDto.getAuthorUuid())) {
+        if (!requestDto.isOwner()) {
             builder.and(feed.visibility.eq(Visibility.VISIBLE));
         }
         Optional.ofNullable(requestDto.getAuthorUuid()).ifPresent(author ->

--- a/src/main/java/com/mulmeong/feed/read/api/infrastructure/HashtagEventRepository.java
+++ b/src/main/java/com/mulmeong/feed/read/api/infrastructure/HashtagEventRepository.java
@@ -1,0 +1,8 @@
+package com.mulmeong.feed.read.api.infrastructure;
+
+import com.mulmeong.feed.read.api.domain.entity.FeedHashtag;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface HashtagEventRepository extends JpaRepository<FeedHashtag, Long> {
+
+}

--- a/src/main/java/com/mulmeong/feed/read/api/infrastructure/HashtagQueryRepository.java
+++ b/src/main/java/com/mulmeong/feed/read/api/infrastructure/HashtagQueryRepository.java
@@ -1,0 +1,13 @@
+package com.mulmeong.feed.read.api.infrastructure;
+
+import com.mulmeong.feed.read.api.domain.entity.FeedHashtag;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface HashtagQueryRepository extends JpaRepository<FeedHashtag, Long> {
+
+    @Query(value = "SELECT * FROM hashtag ORDER BY RAND() LIMIT :size", nativeQuery = true)
+    List<FeedHashtag> getFeedHashtags(int size);
+
+}

--- a/src/main/java/com/mulmeong/feed/read/api/presentation/AuthRequiredFeedQueryController.java
+++ b/src/main/java/com/mulmeong/feed/read/api/presentation/AuthRequiredFeedQueryController.java
@@ -23,22 +23,20 @@ public class AuthRequiredFeedQueryController {
 
     private final FeedQueryService feedQueryService;
 
-    @Operation(summary = "특정 사용자가 작성한 피드 목록 조회",
+    @Operation(summary = "특정 사용자가 작성한 피드 목록 조회 (프로필 페이지의 Owner가 요청시)",
         description = """
-            - **요청자와 작성자의 memberUuid가 같으면** 조건에 맞는 모든 Feed를,
-            같지 않으면 Visibility = `VISIBLE`인 Feed만을 조회<br><br>
+            - 조건에 부합하는 모든 Feed를 조회<br><br>
             - sortBy: `LATEST` / `LIKES` (대·소문자 구분하지 않음)<br><br>
             - LATEST: **최신순**, LIKES: **netLikes 내림차순** (likesCount - dislikeCount)""")
     @GetMapping("/{memberUuid}/feeds")
     public BaseResponse<CursorPage<FeedResponseDto>> getFeedsByAuthor(
         @PathVariable(name = "memberUuid") String authorUuid,
-        @RequestHeader("Member-Uuid") String requesterUuid,
         @RequestParam(defaultValue = "latest", required = false) String sortBy,
         @RequestParam(required = false, name = "nextCursor") String lastId,
         @RequestParam(required = false) Integer pageSize,
         @RequestParam(required = false) Integer pageNo) {
 
         return new BaseResponse<>(feedQueryService.getFeedsByAuthor(FeedAuthorRequestDto.toDto(
-            authorUuid, requesterUuid, sortBy, lastId, pageSize, pageNo)));
+            authorUuid, true, sortBy, lastId, pageSize, pageNo)));
     }
 }

--- a/src/main/java/com/mulmeong/feed/read/api/presentation/AuthRequiredFeedQueryController.java
+++ b/src/main/java/com/mulmeong/feed/read/api/presentation/AuthRequiredFeedQueryController.java
@@ -23,7 +23,7 @@ public class AuthRequiredFeedQueryController {
 
     private final FeedQueryService feedQueryService;
 
-    @Operation(summary = "특정 사용자가 작성한 피드 목록 조회 (프로필 페이지의 Owner가 요청시)",
+    @Operation(summary = "특정 사용자가 작성한 피드 목록 조회 API (프로필 페이지의 Owner가 요청시)",
         description = """
             - 조건에 부합하는 모든 Feed를 조회<br><br>
             - sortBy: `LATEST` / `LIKES` (대·소문자 구분하지 않음)<br><br>

--- a/src/main/java/com/mulmeong/feed/read/api/presentation/FeedQueryController.java
+++ b/src/main/java/com/mulmeong/feed/read/api/presentation/FeedQueryController.java
@@ -1,6 +1,7 @@
 package com.mulmeong.feed.read.api.presentation;
 
 import com.mulmeong.feed.read.api.application.FeedQueryService;
+import com.mulmeong.feed.read.api.domain.model.Hashtag;
 import com.mulmeong.feed.read.api.dto.in.FeedAuthorRequestDto;
 import com.mulmeong.feed.read.api.dto.in.FeedFilterRequestDto;
 import com.mulmeong.feed.read.api.dto.out.FeedResponseDto;
@@ -8,6 +9,7 @@ import com.mulmeong.feed.read.common.response.BaseResponse;
 import com.mulmeong.feed.read.common.utils.CursorPage;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -55,7 +57,7 @@ public class FeedQueryController {
                 categoryName, hashtagName, sortBy, lastId, pageSize, pageNo)));
     }
 
-    @Operation(summary = "특정 사용자가 작성한 피드 목록 조회 (Guest가 요청시)",
+    @Operation(summary = "특정 사용자가 작성한 피드 목록 조회 API (Guest가 요청시)",
         description = """
             - Visibility = `VISIBLE`인 Feed만을 조회<br><br>
             - sortBy: `LATEST` / `LIKES` (대·소문자 구분하지 않음)<br><br>
@@ -70,6 +72,17 @@ public class FeedQueryController {
 
         return new BaseResponse<>(feedQueryService.getFeedsByAuthor(FeedAuthorRequestDto.toDto(
             authorUuid, false, sortBy, lastId, pageSize, pageNo)));
+    }
+
+    @Operation(summary = "랜덤 해시태그 목록 조회 API",
+        description = """
+                      (추후 계획: 유저 관심 태그와 유사한 해시태그 조회 API로 수정 예정)<br><br>
+                      - Size default: **30**""")
+    @GetMapping("/hashtags")
+    public BaseResponse<List<Hashtag>> getFeedHashtags(
+        @RequestParam(required = false, defaultValue = "30") Integer size) {
+
+        return new BaseResponse<>(feedQueryService.getFeedHashtags(size));
     }
 
 }

--- a/src/main/java/com/mulmeong/feed/read/api/presentation/FeedQueryController.java
+++ b/src/main/java/com/mulmeong/feed/read/api/presentation/FeedQueryController.java
@@ -57,7 +57,7 @@ public class FeedQueryController {
 
     @Operation(summary = "특정 사용자가 작성한 피드 목록 조회 (Guest가 요청시)",
         description = """
-            - 조건에 부합하는 모든 Feed를 조회<br><br>
+            - Visibility = `VISIBLE`인 Feed만을 조회<br><br>
             - sortBy: `LATEST` / `LIKES` (대·소문자 구분하지 않음)<br><br>
             - LATEST: **최신순**, LIKES: **netLikes 내림차순** (likesCount - dislikeCount)""")
     @GetMapping("/members/{memberUuid}/feeds")

--- a/src/main/java/com/mulmeong/feed/read/api/presentation/FeedQueryController.java
+++ b/src/main/java/com/mulmeong/feed/read/api/presentation/FeedQueryController.java
@@ -1,6 +1,7 @@
 package com.mulmeong.feed.read.api.presentation;
 
 import com.mulmeong.feed.read.api.application.FeedQueryService;
+import com.mulmeong.feed.read.api.dto.in.FeedAuthorRequestDto;
 import com.mulmeong.feed.read.api.dto.in.FeedFilterRequestDto;
 import com.mulmeong.feed.read.api.dto.out.FeedResponseDto;
 import com.mulmeong.feed.read.common.response.BaseResponse;
@@ -17,7 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Feed Query")
 @RequiredArgsConstructor
-@RequestMapping("/v1/feeds")
+@RequestMapping("/v1")
 @RestController
 @Slf4j
 public class FeedQueryController {
@@ -29,7 +30,7 @@ public class FeedQueryController {
         - MediaType: `IMAGE` / `VIDEO`<br>
         - MediaSubType: `IMAGE` / `VIDEO_THUMBNAIL` / `VIDEO_360` / `VIDEO_540` / `VIDEO_720` / `VIDEO_MP4`<br><br>
         - FeedMedia 테이블은 **FE에서 생성한 MediaUUID를 기본키로 설정**하는 것에 주의""")
-    @GetMapping("/{feedUuid}")
+    @GetMapping("/feeds/{feedUuid}")
     public BaseResponse<FeedResponseDto> getSingleFeed(@PathVariable String feedUuid) {
 
         return new BaseResponse<>(feedQueryService.getSingleFeed(feedUuid));
@@ -40,7 +41,7 @@ public class FeedQueryController {
             - sortBy: `LATEST` / `LIKES` (대·소문자 구분하지 않음)<br><br>
             - LATEST: **최신순**, LIKES: **netLikes 내림차순** (likesCount - dislikeCount)<br><br>
             - Visibility: `VISIBLE`인 피드 목록만 조회""")
-    @GetMapping
+    @GetMapping("/feeds")
     public BaseResponse<CursorPage<FeedResponseDto>> getFeedsByCategoryOrTag(
         @RequestParam(required = false) String categoryName,
         @RequestParam(required = false) String hashtagName,
@@ -52,6 +53,23 @@ public class FeedQueryController {
         return new BaseResponse<>(
             feedQueryService.getFeedsByCategoryOrTag(FeedFilterRequestDto.toDto(
                 categoryName, hashtagName, sortBy, lastId, pageSize, pageNo)));
+    }
+
+    @Operation(summary = "특정 사용자가 작성한 피드 목록 조회 (Guest가 요청시)",
+        description = """
+            - 조건에 부합하는 모든 Feed를 조회<br><br>
+            - sortBy: `LATEST` / `LIKES` (대·소문자 구분하지 않음)<br><br>
+            - LATEST: **최신순**, LIKES: **netLikes 내림차순** (likesCount - dislikeCount)""")
+    @GetMapping("/members/{memberUuid}/feeds")
+    public BaseResponse<CursorPage<FeedResponseDto>> getFeedsByAuthor(
+        @PathVariable(name = "memberUuid") String authorUuid,
+        @RequestParam(defaultValue = "latest", required = false) String sortBy,
+        @RequestParam(required = false, name = "nextCursor") String lastId,
+        @RequestParam(required = false) Integer pageSize,
+        @RequestParam(required = false) Integer pageNo) {
+
+        return new BaseResponse<>(feedQueryService.getFeedsByAuthor(FeedAuthorRequestDto.toDto(
+            authorUuid, false, sortBy, lastId, pageSize, pageNo)));
     }
 
 }

--- a/src/main/java/com/mulmeong/feed/read/common/response/BaseResponseStatus.java
+++ b/src/main/java/com/mulmeong/feed/read/common/response/BaseResponseStatus.java
@@ -29,7 +29,8 @@ public enum BaseResponseStatus {
      * 1000: Feed Service 에러.
      */
     FEED_FORBIDDEN(HttpStatus.FORBIDDEN, false, 1003, "피드 접근 권한이 없습니다."),
-    FEED_NOT_FOUND(HttpStatus.NOT_FOUND, false, 1004, "존재하지 않는 게시글 정보입니다.");
+    FEED_NOT_FOUND(HttpStatus.NOT_FOUND, false, 1004, "존재하지 않는 게시글 정보입니다."),
+    HASHTAG_DUPLICATE_KEY(HttpStatus.CONFLICT, false, 1009, "해시태그가 이미 존재합니다.");
 
     private final HttpStatusCode httpStatusCode;
     private final boolean isSuccess;


### PR DESCRIPTION
<!-- Title: [🚀 (Service名)] (AAA) 기능 구현 -->
<!-- Merge 방향 및 Branch 확인해주세요 -->
<!-- (괄호) 부분은 다 지우고 작성해주세요 -->

### 📅 2024.12.11

### 🌵 Branch
develop → release

### 📢 Description
- 프로필 페이지에서 **요청자가 Owner인지 Guest인지에 따라** 특정 사용자가 작성한 피드 목록 조회 API 분리
- 랜덤 해시태그 조회 API 구현 & Hashtag Create Event Handling

이하 Pull Request 및 Issue 내용 참고

### 📦 Pull Request Number
- #12 
- #10 

### 💬 Issue Number
- #11 
- #9 

### 🔖 Note
- Guest가 요청시: Visibility = `VISIBLE`인 Feed만을 조회
- Owner가 요청시: 조건에 부합하는 모든 Feed를 조회<br><br>

- 임시로 구현해놓고 추후 인기 해시태그 조회 API로 수정 예정
- Hashtag명의 무결성 체크가 간편한 RDB 채택