### PR TITLE
[🚑️ Feed-Read] Pagination 에러 Resolve

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,7 @@ dependencies {
 	// Database
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
+	implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
 
 	// QueryDSL
 	implementation 'com.querydsl:querydsl-core:5.0.0'

--- a/src/main/java/com/mulmeong/feed/read/api/application/FeedSearchService.java
+++ b/src/main/java/com/mulmeong/feed/read/api/application/FeedSearchService.java
@@ -1,0 +1,11 @@
+package com.mulmeong.feed.read.api.application;
+
+import com.mulmeong.feed.read.api.dto.in.FeedSearchRequestDto;
+import com.mulmeong.feed.read.api.dto.out.FeedResponseDto;
+import com.mulmeong.feed.read.common.utils.CursorPage;
+
+public interface FeedSearchService {
+
+    CursorPage<FeedResponseDto> searchFeeds(FeedSearchRequestDto requestDto);
+
+}

--- a/src/main/java/com/mulmeong/feed/read/api/application/FeedSearchServiceImpl.java
+++ b/src/main/java/com/mulmeong/feed/read/api/application/FeedSearchServiceImpl.java
@@ -1,0 +1,97 @@
+package com.mulmeong.feed.read.api.application;
+
+import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import com.mulmeong.feed.read.api.domain.document.ElasticFeed;
+import com.mulmeong.feed.read.api.dto.in.FeedSearchRequestDto;
+import com.mulmeong.feed.read.api.dto.out.FeedResponseDto;
+import com.mulmeong.feed.read.common.utils.CursorPage;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.elasticsearch.client.elc.NativeQuery;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.SearchHit;
+import org.springframework.data.elasticsearch.core.SearchHits;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional(readOnly = true)
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class FeedSearchServiceImpl implements FeedSearchService {
+
+    private static final int DEFAULT_PAGE_SIZE = 20;
+    private static final int DEFAULT_PAGE_NUMBER = 0;
+
+    private final ElasticsearchOperations elasticsearchOperations;
+
+    public CursorPage<FeedResponseDto> searchFeeds(FeedSearchRequestDto requestDto) {
+
+        List<Query> shouldQueries = new ArrayList<>();
+        shouldQueries.add(new Query.Builder()
+            .match(m -> m
+                .field("title")
+                .query(requestDto.getKeyword())
+                .fuzziness("AUTO"))
+            .build());
+
+        shouldQueries.add(new Query.Builder()
+            .match(m -> m
+                .field("content")
+                .query(requestDto.getKeyword())
+                .fuzziness("AUTO"))
+            .build());
+
+        shouldQueries.add(new Query.Builder()
+            .match(m -> m
+                .field("categoryName")
+                .query(requestDto.getKeyword())
+                .fuzziness("AUTO"))
+            .build());
+
+        shouldQueries.add(new Query.Builder()
+            .match(m -> m
+                .field("hashtags.name")
+                .query(requestDto.getKeyword())
+                .fuzziness("AUTO"))
+            .build());
+
+        Query query = new Query.Builder()
+            .bool(new BoolQuery.Builder().should(shouldQueries).build())
+            .build();
+
+        int curPageNo = Optional.ofNullable(requestDto.getPageNo()).orElse(DEFAULT_PAGE_NUMBER);
+        int curPageSize = Optional.ofNullable(requestDto.getPageSize()).orElse(DEFAULT_PAGE_SIZE);
+
+        NativeQuery searchQuery = NativeQuery.builder()
+            .withQuery(query)
+            .withSort(Sort.by(
+                Sort.Order.desc("netLikes"),
+                Sort.Order.desc("createdAt")))
+            .withPageable(PageRequest.of(curPageNo, curPageSize))
+            .build();
+
+        SearchHits<ElasticFeed> searchHits = elasticsearchOperations.search(searchQuery,
+            ElasticFeed.class);
+
+        long totalHits = searchHits.getTotalHits();
+        String nextCursor = null;
+        boolean hasNext = false;
+
+        if (totalHits > curPageSize) {
+            hasNext = true;
+            nextCursor = searchHits.getSearchHit(curPageSize).getContent().getId();
+        }
+
+        return new CursorPage<>(
+            searchHits.stream().map(SearchHit::getContent).map(FeedResponseDto::fromDocument)
+                .toList(), nextCursor, hasNext, searchHits.getSearchHits().size(), curPageNo);
+    }
+
+}

--- a/src/main/java/com/mulmeong/feed/read/api/domain/document/ElasticFeed.java
+++ b/src/main/java/com/mulmeong/feed/read/api/domain/document/ElasticFeed.java
@@ -1,0 +1,89 @@
+package com.mulmeong.feed.read.api.domain.document;
+
+import com.mulmeong.feed.read.api.domain.model.Hashtag;
+import com.mulmeong.feed.read.api.domain.model.Media;
+import com.mulmeong.feed.read.api.domain.model.Visibility;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
+import org.springframework.data.elasticsearch.annotations.Setting;
+
+@Getter
+@Document(indexName = "feed")
+@Setting(replicas = 0)
+@ToString
+public class ElasticFeed {
+
+    @Id
+    private String id;
+
+    @Field(type = FieldType.Keyword, index = false, docValues = false)
+    private String feedUuid;
+
+    @Field(type = FieldType.Keyword, index = false, docValues = false)
+    private String memberUuid;
+
+    @Field(type = FieldType.Text, analyzer = "nori_analyzer", searchAnalyzer = "nori_analyzer")
+    private String title;
+
+    @Field(type = FieldType.Text, analyzer = "nori_analyzer", searchAnalyzer = "nori_analyzer")
+    private String content;
+
+    @Field(type = FieldType.Text, analyzer = "nori_analyzer", searchAnalyzer = "nori_analyzer")
+    private String categoryName;
+
+    @Field(type = FieldType.Text, docValues = false)
+    private Visibility visibility;
+
+    @Field(type = FieldType.Object, analyzer = "nori_analyzer", searchAnalyzer = "nori_analyzer")
+    private List<Hashtag> hashtags;
+
+    @Field(type = FieldType.Object, index = false, docValues = false)
+    private List<Media> mediaList;
+
+    @Field(type = FieldType.Long)
+    private Long likeCount;
+
+    @Field(type = FieldType.Long)
+    private Long dislikeCount;
+
+    @Field(type = FieldType.Long)
+    private Long netLikes;  // Calculated as likeCount - dislikeCount
+
+    @Field(type = FieldType.Long)
+    private Long commentCount;
+
+    @Field(type = FieldType.Date)
+    private String createdAt;
+
+    @Field(type = FieldType.Date)
+    private String updatedAt;
+
+    @Builder
+    public ElasticFeed(String id, String feedUuid, String memberUuid, String title, String content,
+        String categoryName, Visibility visibility, List<Hashtag> hashtags, List<Media> mediaList,
+        Long likeCount, Long dislikeCount, Long netLikes, Long commentCount,
+        String createdAt, String updatedAt) {
+
+        this.id = id;
+        this.feedUuid = feedUuid;
+        this.memberUuid = memberUuid;
+        this.title = title;
+        this.content = content;
+        this.visibility = visibility;
+        this.categoryName = categoryName;
+        this.hashtags = hashtags;
+        this.mediaList = mediaList;
+        this.dislikeCount = dislikeCount;
+        this.likeCount = likeCount;
+        this.netLikes = netLikes;
+        this.createdAt = createdAt;
+        this.commentCount = commentCount;
+        this.updatedAt = updatedAt;
+    }
+}

--- a/src/main/java/com/mulmeong/feed/read/api/dto/in/FeedSearchRequestDto.java
+++ b/src/main/java/com/mulmeong/feed/read/api/dto/in/FeedSearchRequestDto.java
@@ -1,0 +1,29 @@
+package com.mulmeong.feed.read.api.dto.in;
+
+import com.mulmeong.feed.read.api.domain.model.SortType;
+import com.mulmeong.feed.read.api.dto.model.BasePaginationRequestDto;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class FeedSearchRequestDto extends BasePaginationRequestDto {
+
+    private String keyword;
+
+    public static FeedSearchRequestDto toDto(String keyword, Integer pageSize, Integer pageNo) {
+
+        return FeedSearchRequestDto.builder()
+            .keyword(keyword)
+            .pageSize(pageSize)
+            .pageNo(pageNo)
+            .build();
+    }
+
+    @Builder
+    public FeedSearchRequestDto(SortType sortType, String lastId, Integer pageSize, Integer pageNo,
+        String keyword) {
+
+        super(sortType, lastId, pageSize, pageNo);
+        this.keyword = keyword;
+    }
+}

--- a/src/main/java/com/mulmeong/feed/read/api/dto/out/FeedResponseDto.java
+++ b/src/main/java/com/mulmeong/feed/read/api/dto/out/FeedResponseDto.java
@@ -1,5 +1,6 @@
 package com.mulmeong.feed.read.api.dto.out;
 
+import com.mulmeong.feed.read.api.domain.document.ElasticFeed;
 import com.mulmeong.feed.read.api.domain.document.Feed;
 import com.mulmeong.feed.read.api.domain.model.Hashtag;
 import com.mulmeong.feed.read.api.domain.model.Media;
@@ -41,6 +42,24 @@ public class FeedResponseDto {
             .commentCount(feed.getCommentCount())
             .createdAt(feed.getCreatedAt())
             .updatedAt(feed.getUpdatedAt())
+            .build();
+    }
+
+    public static FeedResponseDto fromDocument(ElasticFeed feed) {
+        return FeedResponseDto.builder()
+            .feedUuid(feed.getFeedUuid())
+            .memberUuid(feed.getMemberUuid())
+            .title(feed.getTitle())
+            .content(feed.getContent())
+            .categoryName(feed.getCategoryName())
+            .visibility(feed.getVisibility())
+            .hashtags(feed.getHashtags())
+            .mediaList(feed.getMediaList())
+            .likeCount(feed.getLikeCount())
+            .dislikeCount(feed.getDislikeCount())
+            .commentCount(feed.getCommentCount())
+            .createdAt(LocalDateTime.parse(feed.getCreatedAt()))
+            .updatedAt(LocalDateTime.parse(feed.getUpdatedAt()))
             .build();
     }
 

--- a/src/main/java/com/mulmeong/feed/read/api/infrastructure/FeedCustomRepository.java
+++ b/src/main/java/com/mulmeong/feed/read/api/infrastructure/FeedCustomRepository.java
@@ -23,7 +23,7 @@ import org.springframework.stereotype.Repository;
 public class FeedCustomRepository {     // QueryDSL Repository
 
     private static final int DEFAULT_PAGE_SIZE = 20;
-    private static final int DEFAULT_PAGE_NUMBER = 0;
+    private static final int DEFAULT_PAGE_NUMBER = 1;
 
     private final MongoTemplate mongoTemplate;
     private final QFeed feed = QFeed.feed;
@@ -58,7 +58,10 @@ public class FeedCustomRepository {     // QueryDSL Repository
     private CursorPage<FeedResponseDto> getFeedsWithPagination(BasePaginationRequestDto requestDto,
         BooleanBuilder builder) {
 
-        Optional.ofNullable(requestDto.getLastId()).ifPresent(id -> builder.and(feed.id.lt(id)));
+        if (requestDto.getSortType().equals(SortType.LATEST)) {
+            Optional.ofNullable(requestDto.getLastId())
+                .ifPresent(id -> builder.and(feed.id.loe(id)));
+        }
 
         int curPageNo = Optional.ofNullable(requestDto.getPageNo()).orElse(DEFAULT_PAGE_NUMBER);
         int curPageSize = Optional.ofNullable(requestDto.getPageSize()).orElse(DEFAULT_PAGE_SIZE);
@@ -83,7 +86,7 @@ public class FeedCustomRepository {     // QueryDSL Repository
         }
 
         return new CursorPage<>(content.stream().map(FeedResponseDto::fromDocument).toList(),
-            nextCursor, hasNext, content.size(), requestDto.getPageNo());
+            nextCursor, hasNext, content.size(), curPageNo);
     }
 
     private OrderSpecifier<?> determineSortOrder(QFeed feed, SortType sortType) {

--- a/src/main/java/com/mulmeong/feed/read/api/presentation/FeedQueryController.java
+++ b/src/main/java/com/mulmeong/feed/read/api/presentation/FeedQueryController.java
@@ -11,7 +11,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -22,7 +21,6 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/v1")
 @RestController
-@Slf4j
 public class FeedQueryController {
 
     private final FeedQueryService feedQueryService;

--- a/src/main/java/com/mulmeong/feed/read/api/presentation/FeedQueryController.java
+++ b/src/main/java/com/mulmeong/feed/read/api/presentation/FeedQueryController.java
@@ -40,7 +40,8 @@ public class FeedQueryController {
         description = """
             - sortBy: `LATEST` / `LIKES` (대·소문자 구분하지 않음)<br><br>
             - LATEST: **최신순**, LIKES: **netLikes 내림차순** (likesCount - dislikeCount)<br><br>
-            - Visibility: `VISIBLE`인 피드 목록만 조회""")
+            - Visibility: `VISIBLE`인 피드 목록만 조회<br><br>
+            - sortBy가 `LIKES`일 때는 `nextCursor` 변수를 내부 로직에서 사용하지 않음""")
     @GetMapping("/feeds")
     public BaseResponse<CursorPage<FeedResponseDto>> getFeedsByCategoryOrTag(
         @RequestParam(required = false) String categoryName,

--- a/src/main/java/com/mulmeong/feed/read/api/presentation/FeedSearchController.java
+++ b/src/main/java/com/mulmeong/feed/read/api/presentation/FeedSearchController.java
@@ -1,0 +1,42 @@
+package com.mulmeong.feed.read.api.presentation;
+
+import com.mulmeong.feed.read.api.application.FeedSearchService;
+import com.mulmeong.feed.read.api.dto.in.FeedSearchRequestDto;
+import com.mulmeong.feed.read.api.dto.out.FeedResponseDto;
+import com.mulmeong.feed.read.common.response.BaseResponse;
+import com.mulmeong.feed.read.common.utils.CursorPage;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Feed Search")
+@RequiredArgsConstructor
+@RequestMapping("/v1")
+@RestController
+public class FeedSearchController {
+
+    private final FeedSearchService feedSearchService;
+
+    @Operation(summary = "Feed 검색 API", description = """ 
+        - keyword와 유사한 피드 목록 조회<br><br>
+        - 한글 영어 keyword 모두 가능
+        - title, content, categoryName, hashtags 유사도 측정
+        - 가중치, netLikes, createdAt 내림차순
+        - nextCursor 변수를 반환하긴 하지만, 내부 로직에선 사용할 수 없음""")
+    @GetMapping("/search/feeds/{keyword}")
+    public BaseResponse<CursorPage<FeedResponseDto>> searchFeeds(
+        @PathVariable String keyword,
+        @RequestParam(required = false) Integer pageSize,
+        @RequestParam(required = false) Integer pageNo) {
+
+        return new BaseResponse<>(
+            feedSearchService.searchFeeds(
+                FeedSearchRequestDto.toDto(keyword, pageSize, pageNo)));
+    }
+
+}

--- a/src/main/java/com/mulmeong/feed/read/api/presentation/FeedSearchController.java
+++ b/src/main/java/com/mulmeong/feed/read/api/presentation/FeedSearchController.java
@@ -23,11 +23,11 @@ public class FeedSearchController {
     private final FeedSearchService feedSearchService;
 
     @Operation(summary = "Feed 검색 API", description = """ 
-        - keyword와 유사한 피드 목록 조회<br><br>
-        - 한글 영어 keyword 모두 가능
-        - title, content, categoryName, hashtags 유사도 측정
-        - 가중치, netLikes, createdAt 내림차순
-        - nextCursor 변수를 반환하긴 하지만, 내부 로직에선 사용할 수 없음""")
+        - `keyword`와 유사한 피드 목록 조회<br><br>
+        - 한글·영어 keyword 모두 가능<br><br>
+        - `title`, `content`, `categoryName`, `hashtags` 유사도 측정<br><br>
+        - 가중치 기반의 `netLikes`, `createdAt` 내림차순<br><br>
+        - `nextCursor` 변수를 반환하지만 내부 로직에서 사용하지 않음""")
     @GetMapping("/search/feeds/{keyword}")
     public BaseResponse<CursorPage<FeedResponseDto>> searchFeeds(
         @PathVariable String keyword,

--- a/src/main/java/com/mulmeong/feed/read/common/config/ElasticsearchConfig.java
+++ b/src/main/java/com/mulmeong/feed/read/common/config/ElasticsearchConfig.java
@@ -1,0 +1,28 @@
+package com.mulmeong.feed.read.common.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.elasticsearch.client.ClientConfiguration;
+import org.springframework.data.elasticsearch.client.elc.ElasticsearchConfiguration;
+
+@Configuration
+public class ElasticsearchConfig extends ElasticsearchConfiguration {
+
+    @Value("${spring.elasticsearch.username}")
+    private String username;
+
+    @Value("${spring.elasticsearch.password}")
+    private String password;
+
+    @Value("${spring.elasticsearch.uris}")
+    private String[] esHost;
+
+    @Override
+    public ClientConfiguration clientConfiguration() {
+        return ClientConfiguration.builder()
+            .connectedTo(esHost)
+            .withBasicAuth(username, password)
+            .build();
+    }
+
+}

--- a/src/main/java/com/mulmeong/feed/read/common/response/BaseResponse.java
+++ b/src/main/java/com/mulmeong/feed/read/common/response/BaseResponse.java
@@ -2,11 +2,10 @@ package com.mulmeong.feed.read.common.response;
 
 import com.mulmeong.feed.read.common.utils.TypeCaster;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.HttpStatusCode;
 
 import static com.mulmeong.feed.read.common.response.BaseResponseStatus.SUCCESS;
 
-public record BaseResponse<T>(HttpStatusCode httpStatus, Boolean isSuccess, String message,
+public record BaseResponse<T>(HttpStatus httpStatus, Boolean isSuccess, String message,
                               int code, T result) {
 
     // 필요값 : Http 상태코드, 성공여부, 메시지, 에러코드, 결과값

--- a/src/main/java/com/mulmeong/feed/read/common/response/BaseResponse.java
+++ b/src/main/java/com/mulmeong/feed/read/common/response/BaseResponse.java
@@ -2,11 +2,10 @@ package com.mulmeong.feed.read.common.response;
 
 import com.mulmeong.feed.read.common.utils.TypeCaster;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.HttpStatusCode;
 
 import static com.mulmeong.feed.read.common.response.BaseResponseStatus.SUCCESS;
 
-public record BaseResponse<T>(HttpStatusCode httpStatus, Boolean isSuccess, String message,
+public record BaseResponse<T>(HttpStatus httpStatus, Boolean isSuccess, String message,
                               int code, T result) {
 
     // 필요값 : Http 상태코드, 성공여부, 메시지, 에러코드, 결과값
@@ -34,7 +33,7 @@ public record BaseResponse<T>(HttpStatusCode httpStatus, Boolean isSuccess, Stri
      * @param status 응답 상태
      */
     public BaseResponse(BaseResponseStatus status) {
-        this(status.getHttpStatusCode(), false, status.getMessage(), status.getCode(),
+        this(status.getHttpStatus(), false, status.getMessage(), status.getCode(),
             TypeCaster.castMessage(status.getMessage()));
     }
 
@@ -45,7 +44,7 @@ public record BaseResponse<T>(HttpStatusCode httpStatus, Boolean isSuccess, Stri
      * @param message 에러 메시지
      */
     public BaseResponse(BaseResponseStatus status, String message) {
-        this(status.getHttpStatusCode(), false, message, status.getCode(),
+        this(status.getHttpStatus(), false, message, status.getCode(),
             TypeCaster.castMessage(status.getMessage()));
     }
 

--- a/src/main/java/com/mulmeong/feed/read/common/response/BaseResponseStatus.java
+++ b/src/main/java/com/mulmeong/feed/read/common/response/BaseResponseStatus.java
@@ -3,7 +3,6 @@ package com.mulmeong.feed.read.common.response;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.HttpStatusCode;
 
 @Getter
 @AllArgsConstructor
@@ -32,7 +31,7 @@ public enum BaseResponseStatus {
     FEED_NOT_FOUND(HttpStatus.NOT_FOUND, false, 1004, "존재하지 않는 게시글 정보입니다."),
     HASHTAG_DUPLICATE_KEY(HttpStatus.CONFLICT, false, 1009, "해시태그가 이미 존재합니다.");
 
-    private final HttpStatusCode httpStatusCode;
+    private final HttpStatus httpStatusCode;
     private final boolean isSuccess;
     private final int code;
     private final String message;

--- a/src/main/java/com/mulmeong/feed/read/common/response/BaseResponseStatus.java
+++ b/src/main/java/com/mulmeong/feed/read/common/response/BaseResponseStatus.java
@@ -3,7 +3,6 @@ package com.mulmeong.feed.read.common.response;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.HttpStatusCode;
 
 @Getter
 @AllArgsConstructor
@@ -32,7 +31,7 @@ public enum BaseResponseStatus {
     FEED_NOT_FOUND(HttpStatus.NOT_FOUND, false, 1004, "존재하지 않는 게시글 정보입니다."),
     HASHTAG_DUPLICATE_KEY(HttpStatus.CONFLICT, false, 1009, "해시태그가 이미 존재합니다.");
 
-    private final HttpStatusCode httpStatusCode;
+    private final HttpStatus httpStatus;
     private final boolean isSuccess;
     private final int code;
     private final String message;


### PR DESCRIPTION
<!-- Title: [🚑️ (Service名)] (AAA) 에러 Resolve -->
<!-- Merge 방향 및 Branch 확인해주세요 -->
<!-- (괄호) 부분은 다 지우고 작성해주세요 -->

### 📅 2024.12.16

### 🌵 Branch
hotfix/feed-read/#15 → develop

### 📢 Description
- Pagination에서 nextCursor로 요청을 받았을 때 해당 데이터를 빼고 반환하는 에러
- likes 기준 정렬할 때 같은 데이터가 반복되는 에러

--　--　--　--　--　--　--　--　--　--　--　--　🚑️

### 💬 Issue Number
- #15 

### 🔖 Note
- likes 기준 정렬: **netLikes 내림차순**
- Elasticsearch 관련 일부 구현 사항 포함