### PR TITLE
[🔀 Feed-Read] 피드 생성시 비동기 지연 적용

### DIFF
--- a/src/main/java/com/mulmeong/feed/read/api/application/FeedEventHandlerServiceImpl.java
+++ b/src/main/java/com/mulmeong/feed/read/api/application/FeedEventHandlerServiceImpl.java
@@ -3,6 +3,7 @@ package com.mulmeong.feed.read.api.application;
 import static com.mulmeong.feed.read.common.response.BaseResponseStatus.ELASTICSEARCH_DATA_MISMATCH;
 import static com.mulmeong.feed.read.common.response.BaseResponseStatus.FEED_NOT_FOUND;
 import static com.mulmeong.feed.read.common.response.BaseResponseStatus.HASHTAG_DUPLICATE_KEY;
+import static java.util.stream.Collectors.toList;
 
 import com.mulmeong.feed.read.api.domain.event.FeedCreateEvent;
 import com.mulmeong.feed.read.api.domain.event.FeedDeleteEvent;
@@ -10,10 +11,15 @@ import com.mulmeong.feed.read.api.domain.event.FeedHashtagUpdateEvent;
 import com.mulmeong.feed.read.api.domain.event.FeedMetricsUpdateEvent;
 import com.mulmeong.feed.read.api.domain.event.FeedStatusUpdateEvent;
 import com.mulmeong.feed.read.api.domain.event.FeedUpdateEvent;
+import com.mulmeong.feed.read.api.domain.model.MediaType;
 import com.mulmeong.feed.read.api.infrastructure.ElasticFeedRepository;
 import com.mulmeong.feed.read.api.infrastructure.FeedEventRepository;
 import com.mulmeong.feed.read.api.infrastructure.HashtagEventRepository;
 import com.mulmeong.feed.read.common.exception.BaseException;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -31,15 +37,41 @@ public class FeedEventHandlerServiceImpl implements FeedEventHandlerService {
     @Override
     public void createFeedFromEvent(FeedCreateEvent event) {
 
-        feedEventRepository.save(event.toFeedDocument());
-        elasticFeedRepository.save(event.toElasticDocument());
-        event.toHashtagEntities().forEach(hashtag -> {
-            try {
-                hashtagEventRepository.save(hashtag);
-            } catch (DataIntegrityViolationException e) {
-                log.info("{}: {}", hashtag.getName(), HASHTAG_DUPLICATE_KEY.getMessage());
-            }
-        });
+        Optional.ofNullable(event.getMediaList())
+            .ifPresent(mediaList -> {
+                List<CompletableFuture<Void>> futures = mediaList.stream()
+                    .map(media -> CompletableFuture.runAsync(() -> {
+                        try {
+                            if (media.getMediaType() == MediaType.VIDEO) {
+                                log.info("Processing media asynchronously with a delay of 10 seconds");
+                                TimeUnit.SECONDS.sleep(10);
+                            }
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                            log.error("Delay interrupted: {}", e.getMessage());
+                        }
+                    }))
+                    .toList();
+
+                CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
+                    .thenRun(() -> {
+                        log.info("All media processing completed. Proceeding with save operations.");
+
+                        feedEventRepository.save(event.toFeedDocument());
+                        elasticFeedRepository.save(event.toElasticDocument());
+                        event.toHashtagEntities().forEach(hashtag -> {
+                            try {
+                                hashtagEventRepository.save(hashtag);
+                            } catch (DataIntegrityViolationException e) {
+                                log.info("{}: {}", hashtag.getName(), HASHTAG_DUPLICATE_KEY.getMessage());
+                            }
+                        });
+                    })
+                    .exceptionally(e -> {
+                        log.error("Error occurred while processing media: {}", e.getMessage());
+                        return null;
+                    });
+            });
     }
 
     @Override


### PR DESCRIPTION
<!-- Title: [🔀 (Service名)] (AAA) 기능 구현 -->
<!-- Merge 방향 및 Branch 확인해주세요 -->
<!-- (괄호) 부분은 다 지우고 작성해주세요 -->

### 📅 2024.12.19 ~ 2024.12.19

### 🌵 Branch
feature/feed-read/#19 → develop

### 📢 Description
비디오 데이터는 S3에 업로드된 후 변환 작업을 거쳐 지정된 S3 URL에 다시 업로드 되기까지 평균적으로 약 9초가 소요
=> Delay를 주지 않으면 해당 피드 게시글을 조회할 때 비디오 컨텐츠가 원활히 표시되지 않음
=> 피드 생성시 비디오 파일 하나당 10초의 비동기 Delay를 적용

### 💬 Issue Number
- #19 

### ✔️ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 코드가 정상적으로 동작하는지 테스트 했습니다.

### 🔖 Note
임시 배포 후 테스트 완료