### PR TITLE
[🚀 Feed-Read] 검색 및 추천 API 구현 & 피드 생성시 비동기 지연 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
 	implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
 
+	// Feign client
+	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+
 	// QueryDSL
 	implementation 'com.querydsl:querydsl-core:5.0.0'
 	implementation('com.querydsl:querydsl-mongodb') {

--- a/src/main/java/com/mulmeong/feed/read/FeedReadApplication.java
+++ b/src/main/java/com/mulmeong/feed/read/FeedReadApplication.java
@@ -4,9 +4,11 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 import org.springframework.cloud.context.config.annotation.RefreshScope;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
 @RefreshScope
 @EnableDiscoveryClient
+@EnableFeignClients
 @SpringBootApplication
 public class FeedReadApplication {
 

--- a/src/main/java/com/mulmeong/feed/read/api/application/FeedEventHandlerService.java
+++ b/src/main/java/com/mulmeong/feed/read/api/application/FeedEventHandlerService.java
@@ -3,6 +3,7 @@ package com.mulmeong.feed.read.api.application;
 import com.mulmeong.feed.read.api.domain.event.FeedCreateEvent;
 import com.mulmeong.feed.read.api.domain.event.FeedDeleteEvent;
 import com.mulmeong.feed.read.api.domain.event.FeedHashtagUpdateEvent;
+import com.mulmeong.feed.read.api.domain.event.FeedMetricsUpdateEvent;
 import com.mulmeong.feed.read.api.domain.event.FeedStatusUpdateEvent;
 import com.mulmeong.feed.read.api.domain.event.FeedUpdateEvent;
 
@@ -15,6 +16,8 @@ public interface FeedEventHandlerService {
     void updateFeedStatusFromEvent(FeedStatusUpdateEvent event);
 
     void updateFeedFromEvent(FeedUpdateEvent event);
+
+    void updateFeedMetricsFromEvent(FeedMetricsUpdateEvent event);
 
     void deleteFeedFromEvent(FeedDeleteEvent event);
 

--- a/src/main/java/com/mulmeong/feed/read/api/application/FeedEventHandlerServiceImpl.java
+++ b/src/main/java/com/mulmeong/feed/read/api/application/FeedEventHandlerServiceImpl.java
@@ -31,7 +31,7 @@ public class FeedEventHandlerServiceImpl implements FeedEventHandlerService {
     public void createFeedFromEvent(FeedCreateEvent event) {
 
         feedEventRepository.save(event.toFeedDocument());
-        elasticFeedRepository.save(event.toElasticFeedDocument());
+        elasticFeedRepository.save(event.toElasticDocument());
         event.toHashtagEntities().forEach(hashtag -> {
             try {
                 hashtagEventRepository.save(hashtag);
@@ -47,7 +47,7 @@ public class FeedEventHandlerServiceImpl implements FeedEventHandlerService {
         feedEventRepository.save(
             event.toFeedDocument(feedEventRepository.findByFeedUuid(event.getFeedUuid())
                 .orElseThrow(() -> new BaseException(FEED_NOT_FOUND))));
-        elasticFeedRepository.save(event.toElasticFeedDocument(
+        elasticFeedRepository.save(event.toElasticDocument(
             elasticFeedRepository.findByFeedUuid(event.getFeedUuid())
                 .orElseThrow(() -> new BaseException(ELASTICSEARCH_DATA_MISMATCH))));
     }
@@ -58,7 +58,7 @@ public class FeedEventHandlerServiceImpl implements FeedEventHandlerService {
         feedEventRepository.save(
             event.toDocument(feedEventRepository.findByFeedUuid(event.getFeedUuid())
                 .orElseThrow(() -> new BaseException(FEED_NOT_FOUND))));
-        elasticFeedRepository.save(event.toElasticFeedDocument(
+        elasticFeedRepository.save(event.toElasticDocument(
             elasticFeedRepository.findByFeedUuid(event.getFeedUuid())
                 .orElseThrow(() -> new BaseException(ELASTICSEARCH_DATA_MISMATCH))));
     }
@@ -69,7 +69,7 @@ public class FeedEventHandlerServiceImpl implements FeedEventHandlerService {
         feedEventRepository.save(
             event.toDocument(feedEventRepository.findByFeedUuid(event.getFeedUuid())
                 .orElseThrow(() -> new BaseException(FEED_NOT_FOUND))));
-        elasticFeedRepository.save(event.toElasticFeedDocument(
+        elasticFeedRepository.save(event.toElasticDocument(
             elasticFeedRepository.findByFeedUuid(event.getFeedUuid())
                 .orElseThrow(() -> new BaseException(ELASTICSEARCH_DATA_MISMATCH))));
     }

--- a/src/main/java/com/mulmeong/feed/read/api/application/FeedEventHandlerServiceImpl.java
+++ b/src/main/java/com/mulmeong/feed/read/api/application/FeedEventHandlerServiceImpl.java
@@ -36,7 +36,7 @@ public class FeedEventHandlerServiceImpl implements FeedEventHandlerService {
             try {
                 hashtagEventRepository.save(hashtag);
             } catch (DataIntegrityViolationException e) {
-                log.error("{}: {}", hashtag.getName(), HASHTAG_DUPLICATE_KEY.getMessage());
+                log.info("{}: {}", hashtag.getName(), HASHTAG_DUPLICATE_KEY.getMessage());
             }
         });
     }

--- a/src/main/java/com/mulmeong/feed/read/api/application/FeedEventHandlerServiceImpl.java
+++ b/src/main/java/com/mulmeong/feed/read/api/application/FeedEventHandlerServiceImpl.java
@@ -7,6 +7,7 @@ import static com.mulmeong.feed.read.common.response.BaseResponseStatus.HASHTAG_
 import com.mulmeong.feed.read.api.domain.event.FeedCreateEvent;
 import com.mulmeong.feed.read.api.domain.event.FeedDeleteEvent;
 import com.mulmeong.feed.read.api.domain.event.FeedHashtagUpdateEvent;
+import com.mulmeong.feed.read.api.domain.event.FeedMetricsUpdateEvent;
 import com.mulmeong.feed.read.api.domain.event.FeedStatusUpdateEvent;
 import com.mulmeong.feed.read.api.domain.event.FeedUpdateEvent;
 import com.mulmeong.feed.read.api.infrastructure.ElasticFeedRepository;
@@ -65,6 +66,17 @@ public class FeedEventHandlerServiceImpl implements FeedEventHandlerService {
 
     @Override
     public void updateFeedFromEvent(FeedUpdateEvent event) {
+
+        feedEventRepository.save(
+            event.toDocument(feedEventRepository.findByFeedUuid(event.getFeedUuid())
+                .orElseThrow(() -> new BaseException(FEED_NOT_FOUND))));
+        elasticFeedRepository.save(event.toElasticDocument(
+            elasticFeedRepository.findByFeedUuid(event.getFeedUuid())
+                .orElseThrow(() -> new BaseException(ELASTICSEARCH_DATA_MISMATCH))));
+    }
+
+    @Override
+    public void updateFeedMetricsFromEvent(FeedMetricsUpdateEvent event) {
 
         feedEventRepository.save(
             event.toDocument(feedEventRepository.findByFeedUuid(event.getFeedUuid())

--- a/src/main/java/com/mulmeong/feed/read/api/application/FeedEventHandlerServiceImpl.java
+++ b/src/main/java/com/mulmeong/feed/read/api/application/FeedEventHandlerServiceImpl.java
@@ -3,6 +3,7 @@ package com.mulmeong.feed.read.api.application;
 import static com.mulmeong.feed.read.common.response.BaseResponseStatus.ELASTICSEARCH_DATA_MISMATCH;
 import static com.mulmeong.feed.read.common.response.BaseResponseStatus.FEED_NOT_FOUND;
 import static com.mulmeong.feed.read.common.response.BaseResponseStatus.HASHTAG_DUPLICATE_KEY;
+import static java.util.stream.Collectors.toList;
 
 import com.mulmeong.feed.read.api.domain.event.FeedCreateEvent;
 import com.mulmeong.feed.read.api.domain.event.FeedDeleteEvent;
@@ -10,10 +11,15 @@ import com.mulmeong.feed.read.api.domain.event.FeedHashtagUpdateEvent;
 import com.mulmeong.feed.read.api.domain.event.FeedMetricsUpdateEvent;
 import com.mulmeong.feed.read.api.domain.event.FeedStatusUpdateEvent;
 import com.mulmeong.feed.read.api.domain.event.FeedUpdateEvent;
+import com.mulmeong.feed.read.api.domain.model.MediaType;
 import com.mulmeong.feed.read.api.infrastructure.ElasticFeedRepository;
 import com.mulmeong.feed.read.api.infrastructure.FeedEventRepository;
 import com.mulmeong.feed.read.api.infrastructure.HashtagEventRepository;
 import com.mulmeong.feed.read.common.exception.BaseException;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -31,15 +37,41 @@ public class FeedEventHandlerServiceImpl implements FeedEventHandlerService {
     @Override
     public void createFeedFromEvent(FeedCreateEvent event) {
 
-        feedEventRepository.save(event.toFeedDocument());
-        elasticFeedRepository.save(event.toElasticDocument());
-        event.toHashtagEntities().forEach(hashtag -> {
-            try {
-                hashtagEventRepository.save(hashtag);
-            } catch (DataIntegrityViolationException e) {
-                log.info("{}: {}", hashtag.getName(), HASHTAG_DUPLICATE_KEY.getMessage());
-            }
-        });
+        Optional.ofNullable(event.getMediaList())
+            .ifPresent(mediaList -> {
+                List<CompletableFuture<Void>> futures = mediaList.stream()
+                    .map(media -> CompletableFuture.runAsync(() -> {
+                        try {
+                            if (media.getMediaType() == MediaType.VIDEO) {
+                                log.info("Processing media asynchronously with a delay of 10 seconds");
+                                TimeUnit.SECONDS.sleep(10);
+                            }
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                            log.error("Delay interrupted: {}", e.getMessage());
+                        }
+                    }))
+                    .toList();
+
+                CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
+                    .thenRun(() -> {
+                        log.info("All media processing completed. Proceeding with save operations.");
+
+                        feedEventRepository.save(event.toFeedDocument());
+                        elasticFeedRepository.save(event.toElasticDocument());
+                        event.toHashtagEntities().forEach(hashtag -> {
+                            try {
+                                hashtagEventRepository.save(hashtag);
+                            } catch (DataIntegrityViolationException e) {
+                                log.info("{}: {}", hashtag.getName(), HASHTAG_DUPLICATE_KEY.getMessage());
+                            }
+                        });
+                    })
+                    .exceptionally(e -> {
+                        log.error("Error occurred while processing media: {}", e.getMessage());
+                        return null;
+                    });
+            });
     }
 
     @Override

--- a/src/main/java/com/mulmeong/feed/read/api/application/FeedRecommendService.java
+++ b/src/main/java/com/mulmeong/feed/read/api/application/FeedRecommendService.java
@@ -1,0 +1,11 @@
+package com.mulmeong.feed.read.api.application;
+
+import com.mulmeong.feed.read.api.dto.in.FeedRecommendRequestDto;
+import com.mulmeong.feed.read.api.dto.out.FeedResponseDto;
+import com.mulmeong.feed.read.common.utils.CursorPage;
+
+public interface FeedRecommendService {
+
+    CursorPage<FeedResponseDto> recommendFeeds(FeedRecommendRequestDto requestDto);
+
+}

--- a/src/main/java/com/mulmeong/feed/read/api/application/FeedRecommendServiceImpl.java
+++ b/src/main/java/com/mulmeong/feed/read/api/application/FeedRecommendServiceImpl.java
@@ -1,0 +1,188 @@
+package com.mulmeong.feed.read.api.application;
+
+import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import co.elastic.clients.json.JsonData;
+import com.mulmeong.feed.read.api.domain.document.ElasticFeed;
+import com.mulmeong.feed.read.api.dto.client.CategoryDto;
+import com.mulmeong.feed.read.api.dto.client.HashtagDto;
+import com.mulmeong.feed.read.api.dto.in.FeedRecommendRequestDto;
+import com.mulmeong.feed.read.api.dto.out.FeedResponseDto;
+import com.mulmeong.feed.read.common.utils.CursorPage;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.elasticsearch.client.elc.NativeQuery;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.SearchHit;
+import org.springframework.data.elasticsearch.core.SearchHits;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Slf4j
+@Service
+public class FeedRecommendServiceImpl implements FeedRecommendService {
+
+    private static final int DEFAULT_PAGE_SIZE = 20;
+    private static final int DEFAULT_PAGE_NUMBER = 0;
+
+    private final ElasticsearchOperations elasticsearchOperations;
+    private final FeignService feignService;
+
+    @Transactional(readOnly = true)
+    public CursorPage<FeedResponseDto> recommendFeeds(FeedRecommendRequestDto requestDto) {
+
+        String interestCategory = Optional.ofNullable(
+                feignService.getInterestCategory(requestDto.getMemberUuid()))
+            .filter(list -> !list.isEmpty())
+            .map(list -> list.get(0))
+            .map(CategoryDto::getId)
+            .map(categoryId -> feignService.getCategory(categoryId).getCategoryName())
+            .orElse("일상");
+        String interestHashtag = Optional.ofNullable(
+                feignService.getInterestHashtag(requestDto.getMemberUuid()))
+            .filter(list -> !list.isEmpty())
+            .map(list -> list.get(0))
+            .map(HashtagDto::getName)
+            .orElse("물");
+        List<String> followingList = feignService.getAllFollowings(requestDto.getMemberUuid());
+
+        log.info("Interest Category: {}", interestCategory);
+        log.info("Interest Hashtag: {}", interestHashtag);
+        log.info("Following List: {}", String.join(", ", followingList));
+
+        List<Query> shouldQueries = new ArrayList<>();
+
+        Optional.ofNullable(interestCategory).ifPresent(category -> {
+            shouldQueries.add(new Query.Builder()
+                .match(m -> m
+                    .field("title")
+                    .query(category)
+                    .boost(1.2F)
+                    .fuzziness("AUTO"))
+                .build());
+
+            shouldQueries.add(new Query.Builder()
+                .match(m -> m
+                    .field("content")
+                    .query(category)
+                    .boost(1.2F)
+                    .fuzziness("AUTO"))
+                .build());
+
+            shouldQueries.add(new Query.Builder()
+                .term(m -> m
+                    .field("categoryName")
+                    .value(category)
+                    .boost(2.0F))
+                .build());
+
+            shouldQueries.add(new Query.Builder()
+                .match(m -> m
+                    .field("hashtags.name")
+                    .query(category)
+                    .boost(1.2F)
+                    .fuzziness("AUTO"))
+                .build());
+        });
+
+        Optional.ofNullable(interestHashtag).ifPresent(hashtag -> {
+            shouldQueries.add(new Query.Builder()
+                .match(m -> m
+                    .field("title")
+                    .query(hashtag)
+                    .boost(1.2F)
+                    .fuzziness("AUTO"))
+                .build());
+
+            shouldQueries.add(new Query.Builder()
+                .match(m -> m
+                    .field("content")
+                    .query(hashtag)
+                    .boost(1.2F)
+                    .fuzziness("AUTO"))
+                .build());
+
+            shouldQueries.add(new Query.Builder()
+                .match(m -> m
+                    .field("categoryName")
+                    .query(hashtag)
+                    .boost(1.2F)
+                    .fuzziness("AUTO"))
+                .build());
+
+            shouldQueries.add(new Query.Builder()
+                .match(m -> m
+                    .field("hashtags.name")
+                    .query(hashtag)
+                    .boost(1.6F)
+                    .fuzziness("AUTO"))
+                .build());
+        });
+
+        // 2. Boost based on memberUuid in followingList
+        if (followingList != null && !followingList.isEmpty()) {
+            for (String memberUuid : followingList) {
+                shouldQueries.add(new Query.Builder()
+                    .term(m -> m
+                        .field("memberUuid")
+                        .value(memberUuid)
+                        .boost(4.0F) // Boost for following member
+                    )
+                    .build());
+            }
+        }
+
+        shouldQueries.add(new Query.Builder()
+            .range(r -> r
+                .field("netLikes")
+                .gte(JsonData.of(5)) // Filter for popular content with netLikes >= 5
+                .boost(2.0F) // Boost popular content by 2x
+            )
+            .build());
+
+        Query query = new Query.Builder()
+            .bool(new BoolQuery.Builder().should(shouldQueries).build())
+            .build();
+
+        int curPageNo = Optional.ofNullable(requestDto.getPageNo())
+            .map(pageNo -> pageNo > 0 ? pageNo - 1 : 0).orElse(DEFAULT_PAGE_NUMBER);
+        int curPageSize = Optional.ofNullable(requestDto.getPageSize()).orElse(DEFAULT_PAGE_SIZE);
+
+        NativeQuery searchQuery = NativeQuery.builder()
+            .withQuery(query)
+            .withSort(Sort.by(Sort.Direction.DESC, "_score"))
+            .withPageable(PageRequest.of(curPageNo, curPageSize + 1))
+            .build();
+
+        SearchHits<ElasticFeed> searchHits = elasticsearchOperations.search(searchQuery,
+            ElasticFeed.class);
+
+        for (SearchHit<ElasticFeed> searchHit : searchHits.getSearchHits()) {
+            log.info("Document ID: {}, feedUuid: {}, Score: {}", searchHit.getId(),
+                searchHit.getContent().getFeedUuid(), searchHit.getScore());
+        }
+
+        //        long totalHits = searchHits.getTotalHits();
+        String nextCursor = null;
+        boolean hasNext = false;
+
+        // used for subList
+        List<SearchHit<ElasticFeed>> searchHitList = searchHits.stream().toList();
+
+        if (searchHits.getSearchHits().size() > curPageSize) {
+            hasNext = true;
+            nextCursor = searchHits.getSearchHit(curPageSize).getContent().getId();
+            searchHitList = searchHitList.subList(0, curPageSize);
+        }
+
+        return new CursorPage<>(searchHitList.stream().map(SearchHit::getContent)
+            .map(FeedResponseDto::fromDocument).toList(),
+            nextCursor, hasNext, searchHitList.size(), curPageNo + 1);
+    }
+}

--- a/src/main/java/com/mulmeong/feed/read/api/application/FeedSearchService.java
+++ b/src/main/java/com/mulmeong/feed/read/api/application/FeedSearchService.java
@@ -1,11 +1,14 @@
 package com.mulmeong.feed.read.api.application;
 
 import com.mulmeong.feed.read.api.dto.in.FeedSearchRequestDto;
+import com.mulmeong.feed.read.api.dto.in.IndexSyncRequestDto;
 import com.mulmeong.feed.read.api.dto.out.FeedResponseDto;
 import com.mulmeong.feed.read.common.utils.CursorPage;
 
 public interface FeedSearchService {
 
     CursorPage<FeedResponseDto> searchFeeds(FeedSearchRequestDto requestDto);
+
+    void syncIndex(IndexSyncRequestDto requestDto);
 
 }

--- a/src/main/java/com/mulmeong/feed/read/api/application/FeedSearchService.java
+++ b/src/main/java/com/mulmeong/feed/read/api/application/FeedSearchService.java
@@ -1,5 +1,6 @@
 package com.mulmeong.feed.read.api.application;
 
+import com.mulmeong.feed.read.api.dto.in.FeedRecommendRequestDto;
 import com.mulmeong.feed.read.api.dto.in.FeedSearchRequestDto;
 import com.mulmeong.feed.read.api.dto.in.IndexSyncRequestDto;
 import com.mulmeong.feed.read.api.dto.out.FeedResponseDto;

--- a/src/main/java/com/mulmeong/feed/read/api/application/FeedSearchServiceImpl.java
+++ b/src/main/java/com/mulmeong/feed/read/api/application/FeedSearchServiceImpl.java
@@ -2,9 +2,7 @@ package com.mulmeong.feed.read.api.application;
 
 import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
 import co.elastic.clients.elasticsearch._types.query_dsl.Query;
-import co.elastic.clients.elasticsearch._types.query_dsl.QueryBuilders;
 import com.mulmeong.feed.read.api.domain.document.ElasticFeed;
-import com.mulmeong.feed.read.api.domain.document.Feed;
 import com.mulmeong.feed.read.api.dto.in.FeedSearchRequestDto;
 import com.mulmeong.feed.read.api.dto.in.IndexSyncRequestDto;
 import com.mulmeong.feed.read.api.dto.out.FeedResponseDto;
@@ -74,7 +72,8 @@ public class FeedSearchServiceImpl implements FeedSearchService {
             .bool(new BoolQuery.Builder().should(shouldQueries).build())
             .build();
 
-        int curPageNo = Optional.ofNullable(requestDto.getPageNo()).orElse(DEFAULT_PAGE_NUMBER);
+        int curPageNo = Optional.ofNullable(requestDto.getPageNo())
+            .map(pageNo -> pageNo > 0 ? pageNo - 1 : 0).orElse(DEFAULT_PAGE_NUMBER);
         int curPageSize = Optional.ofNullable(requestDto.getPageSize()).orElse(DEFAULT_PAGE_SIZE);
 
         NativeQuery searchQuery = NativeQuery.builder()
@@ -82,24 +81,25 @@ public class FeedSearchServiceImpl implements FeedSearchService {
             .withSort(Sort.by(
                 Sort.Order.desc("netLikes"),
                 Sort.Order.desc("createdAt")))
-            .withPageable(PageRequest.of(curPageNo, curPageSize))
+            .withPageable(PageRequest.of(curPageNo, curPageSize + 1))
             .build();
 
         SearchHits<ElasticFeed> searchHits = elasticsearchOperations.search(searchQuery,
             ElasticFeed.class);
 
-        long totalHits = searchHits.getTotalHits();
+        //        long totalHits = searchHits.getTotalHits();
         String nextCursor = null;
         boolean hasNext = false;
 
-        if (totalHits > curPageSize) {
+        log.info("{}", searchHits.getSuggest());
+        if (searchHits.getSearchHits().size() > curPageSize) {
             hasNext = true;
             nextCursor = searchHits.getSearchHit(curPageSize).getContent().getId();
         }
 
-        return new CursorPage<>(
-            searchHits.stream().map(SearchHit::getContent).map(FeedResponseDto::fromDocument)
-                .toList(), nextCursor, hasNext, searchHits.getSearchHits().size(), curPageNo);
+        return new CursorPage<>(searchHits.stream().map(SearchHit::getContent)
+            .map(FeedResponseDto::fromDocument).toList(),
+            nextCursor, hasNext, searchHits.getSearchHits().size(), requestDto.getPageNo());
     }
 
     @Transactional
@@ -109,7 +109,6 @@ public class FeedSearchServiceImpl implements FeedSearchService {
         feedCustomRepository.getFeedsForSync(requestDto).forEach(feed -> {
 
             log.info("{}", feed.toString());
-
             elasticFeedRepository.save(
                 elasticFeedRepository.findByFeedUuid(feed.getFeedUuid()).orElse(
                     ElasticFeed.toElasticDocument(feed)));

--- a/src/main/java/com/mulmeong/feed/read/api/application/FeedSearchServiceImpl.java
+++ b/src/main/java/com/mulmeong/feed/read/api/application/FeedSearchServiceImpl.java
@@ -15,7 +15,6 @@ import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.elasticsearch.client.elc.NativeQuery;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
@@ -91,15 +90,19 @@ public class FeedSearchServiceImpl implements FeedSearchService {
         String nextCursor = null;
         boolean hasNext = false;
 
+        // used for subList
+        List<SearchHit<ElasticFeed>> searchHitList = searchHits.stream().toList();
         log.info("{}", searchHits.getSuggest());
+
         if (searchHits.getSearchHits().size() > curPageSize) {
             hasNext = true;
             nextCursor = searchHits.getSearchHit(curPageSize).getContent().getId();
+            searchHitList = searchHitList.subList(0, curPageSize);
         }
 
-        return new CursorPage<>(searchHits.stream().map(SearchHit::getContent)
+        return new CursorPage<>(searchHitList.stream().map(SearchHit::getContent)
             .map(FeedResponseDto::fromDocument).toList(),
-            nextCursor, hasNext, searchHits.getSearchHits().size(), requestDto.getPageNo());
+            nextCursor, hasNext, searchHitList.size(), curPageNo + 1);
     }
 
     @Transactional

--- a/src/main/java/com/mulmeong/feed/read/api/application/FeedSearchServiceImpl.java
+++ b/src/main/java/com/mulmeong/feed/read/api/application/FeedSearchServiceImpl.java
@@ -86,7 +86,7 @@ public class FeedSearchServiceImpl implements FeedSearchService {
         SearchHits<ElasticFeed> searchHits = elasticsearchOperations.search(searchQuery,
             ElasticFeed.class);
 
-        //        long totalHits = searchHits.getTotalHits();
+        // long totalHits = searchHits.getTotalHits();
         String nextCursor = null;
         boolean hasNext = false;
 

--- a/src/main/java/com/mulmeong/feed/read/api/application/FeignService.java
+++ b/src/main/java/com/mulmeong/feed/read/api/application/FeignService.java
@@ -1,0 +1,38 @@
+package com.mulmeong.feed.read.api.application;
+
+import com.mulmeong.feed.read.api.dto.client.CategoryDto;
+import com.mulmeong.feed.read.api.dto.client.CategoryVo;
+import com.mulmeong.feed.read.api.dto.client.HashtagDto;
+import com.mulmeong.feed.read.common.client.AdminClient;
+import com.mulmeong.feed.read.common.client.MemberClient;
+import com.mulmeong.feed.read.common.client.UtilityClient;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@Service
+@RequiredArgsConstructor
+public class FeignService {
+
+    private final MemberClient memberClient;
+    private final UtilityClient utilityClient;
+    private final AdminClient adminClient;
+
+    List<CategoryDto> getInterestCategory(String memberUuid) {
+        return memberClient.getInterestCategory((memberUuid)).result();
+    }
+
+    List<HashtagDto> getInterestHashtag(String memberUuid) {
+        return memberClient.getInterestHashtag((memberUuid)).result();
+    }
+
+    List<String> getAllFollowings(String memberUuid) {
+        return utilityClient.getAllFollowings(memberUuid).result();
+    }
+
+    CategoryVo getCategory(Long categoryId) {
+        return adminClient.getCategory(categoryId).result();
+    }
+
+}

--- a/src/main/java/com/mulmeong/feed/read/api/domain/document/ElasticFeed.java
+++ b/src/main/java/com/mulmeong/feed/read/api/domain/document/ElasticFeed.java
@@ -1,13 +1,20 @@
 package com.mulmeong.feed.read.api.domain.document;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.mulmeong.feed.read.api.domain.model.Hashtag;
 import com.mulmeong.feed.read.api.domain.model.Media;
 import com.mulmeong.feed.read.api.domain.model.Visibility;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Date;
 import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
 import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.DateFormat;
 import org.springframework.data.elasticsearch.annotations.Document;
 import org.springframework.data.elasticsearch.annotations.Field;
 import org.springframework.data.elasticsearch.annotations.FieldType;
@@ -59,16 +66,42 @@ public class ElasticFeed {
     private Long commentCount;
 
     @Field(type = FieldType.Date)
-    private String createdAt;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX||"
+                                                           + "yyyy-MM-dd'T'HH:mm:ss.SSSX||"
+                                                           + "yyyy-MM-dd'T'HH:mm:ss.SSSZ")
+    private ZonedDateTime createdAt;
 
     @Field(type = FieldType.Date)
-    private String updatedAt;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX||"
+                                                           + "yyyy-MM-dd'T'HH:mm:ss.SSSX||"
+                                                           + "yyyy-MM-dd'T'HH:mm:ss.SSSZ")
+    private ZonedDateTime updatedAt;
+
+    public static ElasticFeed toElasticDocument(Feed feed) {
+        return ElasticFeed.builder()
+            .id(feed.getId())
+            .feedUuid(feed.getFeedUuid())
+            .memberUuid(feed.getMemberUuid())
+            .title(feed.getTitle())
+            .content(feed.getContent())
+            .visibility(feed.getVisibility())
+            .categoryName(feed.getCategoryName())
+            .hashtags(feed.getHashtags())
+            .mediaList(feed.getMediaList())
+            .likeCount(feed.getLikeCount())
+            .dislikeCount(feed.getDislikeCount())
+            .netLikes(feed.getNetLikes())
+            .commentCount(feed.getCommentCount())
+            .createdAt(feed.getCreatedAt().atZone(ZoneId.of("Asia/Seoul")))
+            .updatedAt(feed.getUpdatedAt().atZone(ZoneId.of("Asia/Seoul")))
+            .build();
+    }
 
     @Builder
     public ElasticFeed(String id, String feedUuid, String memberUuid, String title, String content,
         String categoryName, Visibility visibility, List<Hashtag> hashtags, List<Media> mediaList,
         Long likeCount, Long dislikeCount, Long netLikes, Long commentCount,
-        String createdAt, String updatedAt) {
+        ZonedDateTime createdAt, ZonedDateTime updatedAt) {
 
         this.id = id;
         this.feedUuid = feedUuid;
@@ -79,11 +112,11 @@ public class ElasticFeed {
         this.categoryName = categoryName;
         this.hashtags = hashtags;
         this.mediaList = mediaList;
-        this.dislikeCount = dislikeCount;
         this.likeCount = likeCount;
+        this.dislikeCount = dislikeCount;
         this.netLikes = netLikes;
-        this.createdAt = createdAt;
         this.commentCount = commentCount;
+        this.createdAt = createdAt;
         this.updatedAt = updatedAt;
     }
 }

--- a/src/main/java/com/mulmeong/feed/read/api/domain/document/Feed.java
+++ b/src/main/java/com/mulmeong/feed/read/api/domain/document/Feed.java
@@ -8,9 +8,11 @@ import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 
+@ToString
 @Getter
 @NoArgsConstructor
 @Document(collection = "feed")

--- a/src/main/java/com/mulmeong/feed/read/api/domain/event/FeedCreateEvent.java
+++ b/src/main/java/com/mulmeong/feed/read/api/domain/event/FeedCreateEvent.java
@@ -1,5 +1,6 @@
 package com.mulmeong.feed.read.api.domain.event;
 
+import com.mulmeong.feed.read.api.domain.document.ElasticFeed;
 import com.mulmeong.feed.read.api.domain.document.Feed;
 import com.mulmeong.feed.read.api.domain.entity.FeedHashtag;
 import com.mulmeong.feed.read.api.domain.model.Hashtag;
@@ -50,6 +51,25 @@ public class FeedCreateEvent {
                 .name(hashtag.getName())
                 .build())
             .toList();
+    }
+
+    public ElasticFeed toElasticFeedDocument() {
+        return ElasticFeed.builder()
+            .feedUuid(feedUuid)
+            .memberUuid(memberUuid)
+            .title(title)
+            .content(content)
+            .categoryName(categoryName)
+            .visibility(visibility)
+            .hashtags(hashtags)
+            .mediaList(mediaList)
+            .likeCount(0L)
+            .dislikeCount(0L)
+            .netLikes(0L)
+            .commentCount(0L)
+            .createdAt(createdAt.toString())
+            .updatedAt(updatedAt.toString())
+            .build();
     }
 
 }

--- a/src/main/java/com/mulmeong/feed/read/api/domain/event/FeedCreateEvent.java
+++ b/src/main/java/com/mulmeong/feed/read/api/domain/event/FeedCreateEvent.java
@@ -7,6 +7,7 @@ import com.mulmeong.feed.read.api.domain.model.Hashtag;
 import com.mulmeong.feed.read.api.domain.model.Media;
 import com.mulmeong.feed.read.api.domain.model.Visibility;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.List;
 import lombok.Getter;
 import lombok.ToString;
@@ -53,7 +54,7 @@ public class FeedCreateEvent {
             .toList();
     }
 
-    public ElasticFeed toElasticFeedDocument() {
+    public ElasticFeed toElasticDocument() {
         return ElasticFeed.builder()
             .feedUuid(feedUuid)
             .memberUuid(memberUuid)
@@ -67,8 +68,8 @@ public class FeedCreateEvent {
             .dislikeCount(0L)
             .netLikes(0L)
             .commentCount(0L)
-            .createdAt(createdAt.toString())
-            .updatedAt(updatedAt.toString())
+            .createdAt(createdAt.atZone(ZoneId.of("Asia/Seoul")))
+            .updatedAt(updatedAt.atZone(ZoneId.of("Asia/Seoul")))
             .build();
     }
 

--- a/src/main/java/com/mulmeong/feed/read/api/domain/event/FeedHashtagUpdateEvent.java
+++ b/src/main/java/com/mulmeong/feed/read/api/domain/event/FeedHashtagUpdateEvent.java
@@ -1,5 +1,6 @@
 package com.mulmeong.feed.read.api.domain.event;
 
+import com.mulmeong.feed.read.api.domain.document.ElasticFeed;
 import com.mulmeong.feed.read.api.domain.document.Feed;
 import com.mulmeong.feed.read.api.domain.model.Hashtag;
 import java.time.LocalDateTime;
@@ -15,7 +16,7 @@ public class FeedHashtagUpdateEvent {
     private List<Hashtag> hashtags;
     private LocalDateTime updatedAt;
 
-    public Feed toDocument(Feed existingFeed) {
+    public Feed toFeedDocument(Feed existingFeed) {
         return Feed.builder()
             .id(existingFeed.getId())
             .feedUuid(feedUuid)
@@ -32,6 +33,26 @@ public class FeedHashtagUpdateEvent {
             .commentCount(existingFeed.getCommentCount())
             .createdAt(existingFeed.getCreatedAt())
             .updatedAt(updatedAt)
+            .build();
+    }
+
+    public ElasticFeed toElasticFeedDocument(ElasticFeed existingElasticFeed) {
+        return ElasticFeed.builder()
+            .id(existingElasticFeed.getId())
+            .feedUuid(feedUuid)
+            .memberUuid(existingElasticFeed.getMemberUuid())
+            .title(existingElasticFeed.getTitle())
+            .content(existingElasticFeed.getContent())
+            .categoryName(existingElasticFeed.getCategoryName())
+            .visibility(existingElasticFeed.getVisibility())
+            .hashtags(hashtags)
+            .mediaList(existingElasticFeed.getMediaList())
+            .likeCount(existingElasticFeed.getLikeCount())
+            .dislikeCount(existingElasticFeed.getDislikeCount())
+            .netLikes(existingElasticFeed.getNetLikes())
+            .commentCount(existingElasticFeed.getCommentCount())
+            .createdAt(existingElasticFeed.getCreatedAt())
+            .updatedAt(updatedAt.toString())
             .build();
     }
 

--- a/src/main/java/com/mulmeong/feed/read/api/domain/event/FeedHashtagUpdateEvent.java
+++ b/src/main/java/com/mulmeong/feed/read/api/domain/event/FeedHashtagUpdateEvent.java
@@ -4,6 +4,7 @@ import com.mulmeong.feed.read.api.domain.document.ElasticFeed;
 import com.mulmeong.feed.read.api.domain.document.Feed;
 import com.mulmeong.feed.read.api.domain.model.Hashtag;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.List;
 import lombok.Getter;
 import lombok.ToString;
@@ -36,7 +37,7 @@ public class FeedHashtagUpdateEvent {
             .build();
     }
 
-    public ElasticFeed toElasticFeedDocument(ElasticFeed existingElasticFeed) {
+    public ElasticFeed toElasticDocument(ElasticFeed existingElasticFeed) {
         return ElasticFeed.builder()
             .id(existingElasticFeed.getId())
             .feedUuid(feedUuid)
@@ -52,7 +53,7 @@ public class FeedHashtagUpdateEvent {
             .netLikes(existingElasticFeed.getNetLikes())
             .commentCount(existingElasticFeed.getCommentCount())
             .createdAt(existingElasticFeed.getCreatedAt())
-            .updatedAt(updatedAt.toString())
+            .updatedAt(updatedAt.atZone(ZoneId.of("Asia/Seoul")))
             .build();
     }
 

--- a/src/main/java/com/mulmeong/feed/read/api/domain/event/FeedMetricsUpdateEvent.java
+++ b/src/main/java/com/mulmeong/feed/read/api/domain/event/FeedMetricsUpdateEvent.java
@@ -1,0 +1,56 @@
+package com.mulmeong.feed.read.api.domain.event;
+
+import com.mulmeong.feed.read.api.domain.document.ElasticFeed;
+import com.mulmeong.feed.read.api.domain.document.Feed;
+import java.time.ZoneId;
+import lombok.Getter;
+
+@Getter
+public class FeedMetricsUpdateEvent {
+
+    private String feedUuid;
+    private Long likeCount;
+    private Long dislikeCount;
+    private Long commentCount;
+
+    public Feed toDocument(Feed existingFeed) {
+        return Feed.builder()
+            .id(existingFeed.getId())
+            .feedUuid(feedUuid)
+            .memberUuid(existingFeed.getMemberUuid())
+            .title(existingFeed.getTitle())
+            .content(existingFeed.getContent())
+            .categoryName(existingFeed.getCategoryName())
+            .visibility(existingFeed.getVisibility())
+            .hashtags(existingFeed.getHashtags())
+            .mediaList(existingFeed.getMediaList())
+            .likeCount(likeCount)
+            .dislikeCount(dislikeCount)
+            .netLikes(likeCount - dislikeCount)
+            .commentCount(commentCount)
+            .createdAt(existingFeed.getCreatedAt())
+            .updatedAt(existingFeed.getUpdatedAt())
+            .build();
+    }
+
+    public ElasticFeed toElasticDocument(ElasticFeed existingElasticFeed) {
+        return ElasticFeed.builder()
+            .id(existingElasticFeed.getId())
+            .feedUuid(feedUuid)
+            .memberUuid(existingElasticFeed.getMemberUuid())
+            .title(existingElasticFeed.getTitle())
+            .content(existingElasticFeed.getContent())
+            .categoryName(existingElasticFeed.getCategoryName())
+            .visibility(existingElasticFeed.getVisibility())
+            .hashtags(existingElasticFeed.getHashtags())
+            .mediaList(existingElasticFeed.getMediaList())
+            .likeCount(likeCount)
+            .dislikeCount(dislikeCount)
+            .netLikes(likeCount - dislikeCount)
+            .commentCount(commentCount)
+            .createdAt(existingElasticFeed.getCreatedAt())
+            .updatedAt(existingElasticFeed.getUpdatedAt())
+            .build();
+    }
+
+}

--- a/src/main/java/com/mulmeong/feed/read/api/domain/event/FeedStatusUpdateEvent.java
+++ b/src/main/java/com/mulmeong/feed/read/api/domain/event/FeedStatusUpdateEvent.java
@@ -1,5 +1,6 @@
 package com.mulmeong.feed.read.api.domain.event;
 
+import com.mulmeong.feed.read.api.domain.document.ElasticFeed;
 import com.mulmeong.feed.read.api.domain.document.Feed;
 import com.mulmeong.feed.read.api.domain.model.Hashtag;
 import com.mulmeong.feed.read.api.domain.model.Visibility;
@@ -33,6 +34,26 @@ public class FeedStatusUpdateEvent {
             .commentCount(existingFeed.getCommentCount())
             .createdAt(existingFeed.getCreatedAt())
             .updatedAt(updatedAt)
+            .build();
+    }
+
+    public ElasticFeed toElasticFeedDocument(ElasticFeed existingElasticFeed) {
+        return ElasticFeed.builder()
+            .id(existingElasticFeed.getId())
+            .feedUuid(feedUuid)
+            .memberUuid(existingElasticFeed.getMemberUuid())
+            .title(existingElasticFeed.getTitle())
+            .content(existingElasticFeed.getContent())
+            .categoryName(existingElasticFeed.getCategoryName())
+            .visibility(visibility)
+            .hashtags(existingElasticFeed.getHashtags())
+            .mediaList(existingElasticFeed.getMediaList())
+            .likeCount(existingElasticFeed.getLikeCount())
+            .dislikeCount(existingElasticFeed.getDislikeCount())
+            .netLikes(existingElasticFeed.getNetLikes())
+            .commentCount(existingElasticFeed.getCommentCount())
+            .createdAt(existingElasticFeed.getCreatedAt())
+            .updatedAt(updatedAt.toString())
             .build();
     }
 

--- a/src/main/java/com/mulmeong/feed/read/api/domain/event/FeedStatusUpdateEvent.java
+++ b/src/main/java/com/mulmeong/feed/read/api/domain/event/FeedStatusUpdateEvent.java
@@ -5,6 +5,7 @@ import com.mulmeong.feed.read.api.domain.document.Feed;
 import com.mulmeong.feed.read.api.domain.model.Hashtag;
 import com.mulmeong.feed.read.api.domain.model.Visibility;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.List;
 import lombok.Getter;
 import lombok.ToString;
@@ -37,7 +38,7 @@ public class FeedStatusUpdateEvent {
             .build();
     }
 
-    public ElasticFeed toElasticFeedDocument(ElasticFeed existingElasticFeed) {
+    public ElasticFeed toElasticDocument(ElasticFeed existingElasticFeed) {
         return ElasticFeed.builder()
             .id(existingElasticFeed.getId())
             .feedUuid(feedUuid)
@@ -53,7 +54,7 @@ public class FeedStatusUpdateEvent {
             .netLikes(existingElasticFeed.getNetLikes())
             .commentCount(existingElasticFeed.getCommentCount())
             .createdAt(existingElasticFeed.getCreatedAt())
-            .updatedAt(updatedAt.toString())
+            .updatedAt(updatedAt.atZone(ZoneId.of("Asia/Seoul")))
             .build();
     }
 

--- a/src/main/java/com/mulmeong/feed/read/api/domain/event/FeedUpdateEvent.java
+++ b/src/main/java/com/mulmeong/feed/read/api/domain/event/FeedUpdateEvent.java
@@ -1,5 +1,6 @@
 package com.mulmeong.feed.read.api.domain.event;
 
+import com.mulmeong.feed.read.api.domain.document.ElasticFeed;
 import com.mulmeong.feed.read.api.domain.document.Feed;
 import java.time.LocalDateTime;
 import lombok.Getter;
@@ -32,6 +33,26 @@ public class FeedUpdateEvent {
             .commentCount(existingFeed.getCommentCount())
             .createdAt(existingFeed.getCreatedAt())
             .updatedAt(updatedAt)
+            .build();
+    }
+
+    public ElasticFeed toElasticFeedDocument(ElasticFeed existingElasticFeed) {
+        return ElasticFeed.builder()
+            .id(existingElasticFeed.getId())
+            .feedUuid(feedUuid)
+            .memberUuid(existingElasticFeed.getMemberUuid())
+            .title(title)
+            .content(content)
+            .categoryName(categoryName)
+            .visibility(existingElasticFeed.getVisibility())
+            .hashtags(existingElasticFeed.getHashtags())
+            .mediaList(existingElasticFeed.getMediaList())
+            .likeCount(existingElasticFeed.getLikeCount())
+            .dislikeCount(existingElasticFeed.getDislikeCount())
+            .netLikes(existingElasticFeed.getNetLikes())
+            .commentCount(existingElasticFeed.getCommentCount())
+            .createdAt(existingElasticFeed.getCreatedAt())
+            .updatedAt(updatedAt.toString())
             .build();
     }
 

--- a/src/main/java/com/mulmeong/feed/read/api/domain/event/FeedUpdateEvent.java
+++ b/src/main/java/com/mulmeong/feed/read/api/domain/event/FeedUpdateEvent.java
@@ -3,6 +3,7 @@ package com.mulmeong.feed.read.api.domain.event;
 import com.mulmeong.feed.read.api.domain.document.ElasticFeed;
 import com.mulmeong.feed.read.api.domain.document.Feed;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import lombok.Getter;
 import lombok.ToString;
 
@@ -36,7 +37,7 @@ public class FeedUpdateEvent {
             .build();
     }
 
-    public ElasticFeed toElasticFeedDocument(ElasticFeed existingElasticFeed) {
+    public ElasticFeed toElasticDocument(ElasticFeed existingElasticFeed) {
         return ElasticFeed.builder()
             .id(existingElasticFeed.getId())
             .feedUuid(feedUuid)
@@ -52,7 +53,7 @@ public class FeedUpdateEvent {
             .netLikes(existingElasticFeed.getNetLikes())
             .commentCount(existingElasticFeed.getCommentCount())
             .createdAt(existingElasticFeed.getCreatedAt())
-            .updatedAt(updatedAt.toString())
+            .updatedAt(updatedAt.atZone(ZoneId.of("Asia/Seoul")))
             .build();
     }
 

--- a/src/main/java/com/mulmeong/feed/read/api/dto/client/CategoryDto.java
+++ b/src/main/java/com/mulmeong/feed/read/api/dto/client/CategoryDto.java
@@ -1,0 +1,15 @@
+package com.mulmeong.feed.read.api.dto.client;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Builder
+@AllArgsConstructor
+public class CategoryDto {
+
+    private Long id;
+}

--- a/src/main/java/com/mulmeong/feed/read/api/dto/client/CategoryVo.java
+++ b/src/main/java/com/mulmeong/feed/read/api/dto/client/CategoryVo.java
@@ -1,0 +1,19 @@
+package com.mulmeong.feed.read.api.dto.client;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class CategoryVo {
+    private Long categoryId;
+    private String categoryName;
+    private String viewType;
+
+    @Builder
+    public CategoryVo(Long categoryId, String categoryName, String viewType) {
+        this.categoryId = categoryId;
+        this.categoryName = categoryName;
+        this.viewType = viewType;
+    }
+
+}

--- a/src/main/java/com/mulmeong/feed/read/api/dto/client/HashtagDto.java
+++ b/src/main/java/com/mulmeong/feed/read/api/dto/client/HashtagDto.java
@@ -1,0 +1,16 @@
+package com.mulmeong.feed.read.api.dto.client;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Builder
+@AllArgsConstructor
+public class HashtagDto {
+
+    private String name;
+
+}

--- a/src/main/java/com/mulmeong/feed/read/api/dto/in/FeedRecommendRequestDto.java
+++ b/src/main/java/com/mulmeong/feed/read/api/dto/in/FeedRecommendRequestDto.java
@@ -1,0 +1,30 @@
+package com.mulmeong.feed.read.api.dto.in;
+
+import com.mulmeong.feed.read.api.domain.model.SortType;
+import com.mulmeong.feed.read.api.dto.model.BasePaginationRequestDto;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class FeedRecommendRequestDto extends BasePaginationRequestDto {
+
+    private String memberUuid;
+
+    public static FeedRecommendRequestDto toDto(String memberUuid, Integer pageSize,
+        Integer pageNo) {
+
+        return FeedRecommendRequestDto.builder()
+            .memberUuid(memberUuid)
+            .pageSize(pageSize)
+            .pageNo(pageNo)
+            .build();
+    }
+
+    @Builder
+    public FeedRecommendRequestDto(String memberUuid, SortType sortType, String lastId,
+        Integer pageSize, Integer pageNo) {
+
+        super(sortType, lastId, pageSize, pageNo);
+        this.memberUuid = memberUuid;
+    }
+}

--- a/src/main/java/com/mulmeong/feed/read/api/dto/in/IndexSyncRequestDto.java
+++ b/src/main/java/com/mulmeong/feed/read/api/dto/in/IndexSyncRequestDto.java
@@ -1,0 +1,26 @@
+package com.mulmeong.feed.read.api.dto.in;
+
+import com.mulmeong.feed.read.api.vo.in.IndexSyncRequestVo;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class IndexSyncRequestDto {
+
+    private String lastId;
+    private Integer limit;
+
+    public static IndexSyncRequestDto toDto(IndexSyncRequestVo requestVo) {
+        return IndexSyncRequestDto.builder()
+            .offset(requestVo.getLastId())
+            .limit(requestVo.getLimit())
+            .build();
+    }
+
+    @Builder
+    public IndexSyncRequestDto(String offset, Integer limit) {
+        this.lastId = offset;
+        this.limit = limit;
+    }
+
+}

--- a/src/main/java/com/mulmeong/feed/read/api/dto/out/FeedResponseDto.java
+++ b/src/main/java/com/mulmeong/feed/read/api/dto/out/FeedResponseDto.java
@@ -45,21 +45,21 @@ public class FeedResponseDto {
             .build();
     }
 
-    public static FeedResponseDto fromDocument(ElasticFeed feed) {
+    public static FeedResponseDto fromDocument(ElasticFeed elasticFeed) {
         return FeedResponseDto.builder()
-            .feedUuid(feed.getFeedUuid())
-            .memberUuid(feed.getMemberUuid())
-            .title(feed.getTitle())
-            .content(feed.getContent())
-            .categoryName(feed.getCategoryName())
-            .visibility(feed.getVisibility())
-            .hashtags(feed.getHashtags())
-            .mediaList(feed.getMediaList())
-            .likeCount(feed.getLikeCount())
-            .dislikeCount(feed.getDislikeCount())
-            .commentCount(feed.getCommentCount())
-            .createdAt(LocalDateTime.parse(feed.getCreatedAt()))
-            .updatedAt(LocalDateTime.parse(feed.getUpdatedAt()))
+            .feedUuid(elasticFeed.getFeedUuid())
+            .memberUuid(elasticFeed.getMemberUuid())
+            .title(elasticFeed.getTitle())
+            .content(elasticFeed.getContent())
+            .categoryName(elasticFeed.getCategoryName())
+            .visibility(elasticFeed.getVisibility())
+            .hashtags(elasticFeed.getHashtags())
+            .mediaList(elasticFeed.getMediaList())
+            .likeCount(elasticFeed.getLikeCount())
+            .dislikeCount(elasticFeed.getDislikeCount())
+            .commentCount(elasticFeed.getCommentCount())
+            .createdAt(elasticFeed.getCreatedAt().toLocalDateTime())
+            .updatedAt(elasticFeed.getUpdatedAt().toLocalDateTime())
             .build();
     }
 

--- a/src/main/java/com/mulmeong/feed/read/api/infrastructure/ElasticFeedRepository.java
+++ b/src/main/java/com/mulmeong/feed/read/api/infrastructure/ElasticFeedRepository.java
@@ -1,0 +1,13 @@
+package com.mulmeong.feed.read.api.infrastructure;
+
+import com.mulmeong.feed.read.api.domain.document.ElasticFeed;
+import java.util.Optional;
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+
+public interface ElasticFeedRepository extends ElasticsearchRepository<ElasticFeed, String> {
+
+    Optional<ElasticFeed> findByFeedUuid(String feedUuid);
+
+    void deleteByFeedUuid(String feedUuid);
+
+}

--- a/src/main/java/com/mulmeong/feed/read/api/infrastructure/FeedCustomRepository.java
+++ b/src/main/java/com/mulmeong/feed/read/api/infrastructure/FeedCustomRepository.java
@@ -6,6 +6,7 @@ import com.mulmeong.feed.read.api.domain.model.SortType;
 import com.mulmeong.feed.read.api.domain.model.Visibility;
 import com.mulmeong.feed.read.api.dto.in.FeedAuthorRequestDto;
 import com.mulmeong.feed.read.api.dto.in.FeedFilterRequestDto;
+import com.mulmeong.feed.read.api.dto.in.IndexSyncRequestDto;
 import com.mulmeong.feed.read.api.dto.model.BasePaginationRequestDto;
 import com.mulmeong.feed.read.api.dto.out.FeedResponseDto;
 import com.mulmeong.feed.read.common.utils.CursorPage;
@@ -53,6 +54,22 @@ public class FeedCustomRepository {     // QueryDSL Repository
             builder.and(feed.memberUuid.eq(author)));
 
         return getFeedsWithPagination(requestDto, builder);
+    }
+
+    public List<Feed> getFeedsForSync(IndexSyncRequestDto requestDto) {
+
+        BooleanBuilder builder = new BooleanBuilder();
+
+        Optional.ofNullable(requestDto.getLastId()).ifPresent(id -> builder.and(feed.id.goe(id)));
+
+        SpringDataMongodbQuery<Feed> query = new SpringDataMongodbQuery<>(mongoTemplate,
+            Feed.class).where(builder);
+
+        Optional.ofNullable(requestDto.getLimit())
+            .filter(limit -> limit > 0)
+            .ifPresent(query::limit);
+
+        return query.fetch();
     }
 
     private CursorPage<FeedResponseDto> getFeedsWithPagination(BasePaginationRequestDto requestDto,

--- a/src/main/java/com/mulmeong/feed/read/api/infrastructure/FeedCustomRepository.java
+++ b/src/main/java/com/mulmeong/feed/read/api/infrastructure/FeedCustomRepository.java
@@ -85,9 +85,9 @@ public class FeedCustomRepository {     // QueryDSL Repository
         int curPageNo = Optional.ofNullable(requestDto.getPageNo())
             .map(pageNo -> pageNo > 0 ? pageNo - 1 : 0).orElse(DEFAULT_PAGE_NUMBER);
         int curPageSize = Optional.ofNullable(requestDto.getPageSize()).orElse(DEFAULT_PAGE_SIZE);
-        int offset = Math.max(0, (curPageNo - 1) * curPageSize);
+        int offset = Math.max(0, curPageNo * curPageSize);
 
-        log.info("{}", curPageNo);
+        // log.info("curPageNo: {}, offset: {}", curPageNo, offset);
         SpringDataMongodbQuery<Feed> query = new SpringDataMongodbQuery<>(mongoTemplate,
             Feed.class);
 
@@ -110,11 +110,11 @@ public class FeedCustomRepository {     // QueryDSL Repository
             nextCursor, hasNext, content.size(), curPageNo + 1);
     }
 
-    private OrderSpecifier<?> determineSortOrder(QFeed feed, SortType sortType) {
+    private OrderSpecifier<?>[] determineSortOrder(QFeed feed, SortType sortType) {
 
         return switch (sortType) {
-            case LATEST -> feed.createdAt.desc();
-            case LIKES -> feed.netLikes.desc();
+            case LATEST -> new OrderSpecifier<?>[] { feed.createdAt.desc() };
+            case LIKES -> new OrderSpecifier<?>[] {feed.netLikes.desc(), feed.updatedAt.desc() };
         };
     }
 

--- a/src/main/java/com/mulmeong/feed/read/api/infrastructure/FeedEventRepository.java
+++ b/src/main/java/com/mulmeong/feed/read/api/infrastructure/FeedEventRepository.java
@@ -1,7 +1,9 @@
 package com.mulmeong.feed.read.api.infrastructure;
 
 import com.mulmeong.feed.read.api.domain.document.Feed;
+import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.repository.MongoRepository;
 
 public interface FeedEventRepository extends MongoRepository<Feed, String> {

--- a/src/main/java/com/mulmeong/feed/read/api/infrastructure/KafkaConsumer.java
+++ b/src/main/java/com/mulmeong/feed/read/api/infrastructure/KafkaConsumer.java
@@ -4,6 +4,7 @@ import com.mulmeong.feed.read.api.application.FeedEventHandlerService;
 import com.mulmeong.feed.read.api.domain.event.FeedCreateEvent;
 import com.mulmeong.feed.read.api.domain.event.FeedDeleteEvent;
 import com.mulmeong.feed.read.api.domain.event.FeedHashtagUpdateEvent;
+import com.mulmeong.feed.read.api.domain.event.FeedMetricsUpdateEvent;
 import com.mulmeong.feed.read.api.domain.event.FeedStatusUpdateEvent;
 import com.mulmeong.feed.read.api.domain.event.FeedUpdateEvent;
 import lombok.RequiredArgsConstructor;
@@ -61,6 +62,15 @@ public class KafkaConsumer {
         log.info("Consumed feed-updated event: {}", event);
         feedEventHandlerService.updateFeedFromEvent(event);
         log.info("Successfully processed feed-updated event: {}", event);
+    }
+
+    @KafkaListener(topics = "${event.feed.pub.topics.feed-metrics-update.name}",
+        containerFactory = "feedMetricsUpdateEventListener")
+    public void consumeFeedMetricsUpdateEvent(FeedMetricsUpdateEvent event) {
+
+        log.info("Consumed feed-metrics-updated event: {}", event);
+        feedEventHandlerService.updateFeedMetricsFromEvent(event);
+        log.info("Successfully processed feed-metrics-updated event: {}", event);
     }
 
 }

--- a/src/main/java/com/mulmeong/feed/read/api/presentation/AuthRequiredFeedQueryController.java
+++ b/src/main/java/com/mulmeong/feed/read/api/presentation/AuthRequiredFeedQueryController.java
@@ -1,7 +1,9 @@
 package com.mulmeong.feed.read.api.presentation;
 
 import com.mulmeong.feed.read.api.application.FeedQueryService;
+import com.mulmeong.feed.read.api.application.FeedRecommendService;
 import com.mulmeong.feed.read.api.dto.in.FeedAuthorRequestDto;
+import com.mulmeong.feed.read.api.dto.in.FeedRecommendRequestDto;
 import com.mulmeong.feed.read.api.dto.out.FeedResponseDto;
 import com.mulmeong.feed.read.common.response.BaseResponse;
 import com.mulmeong.feed.read.common.utils.CursorPage;
@@ -22,6 +24,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthRequiredFeedQueryController {
 
     private final FeedQueryService feedQueryService;
+    private final FeedRecommendService feedRecommendService;
 
     @Operation(summary = "특정 사용자가 작성한 피드 목록 조회 API (프로필 페이지의 Owner가 요청시)",
         description = """
@@ -39,4 +42,21 @@ public class AuthRequiredFeedQueryController {
         return new BaseResponse<>(feedQueryService.getFeedsByAuthor(FeedAuthorRequestDto.toDto(
             authorUuid, true, sortBy, lastId, pageSize, pageNo)));
     }
+
+    @Operation(summary = "Feed 추천 API",
+        description = """
+            - 해당 멤버의 관심 카테고리 / 관심 해시태그 / 팔로잉 멤버 기반 추천<br><br>
+            - (임시) 관심 카테고리가 null일 때는 관심 카테고리를 **일상**으로 설정<br><br>
+            - (임시) 관심 해시태그가 null일 때는 관심 해시태그를 **물**로 설정""")
+    @GetMapping("{memberUuid}/recommend/feeds")
+    public BaseResponse<CursorPage<FeedResponseDto>> recommendFeeds(
+        @PathVariable String memberUuid,
+        @RequestParam(required = false) Integer pageSize,
+        @RequestParam(required = false) Integer pageNo) {
+
+        return new BaseResponse<>(
+            feedRecommendService.recommendFeeds(
+                FeedRecommendRequestDto.toDto(memberUuid, pageSize, pageNo)));
+    }
+
 }

--- a/src/main/java/com/mulmeong/feed/read/api/presentation/FeedSearchController.java
+++ b/src/main/java/com/mulmeong/feed/read/api/presentation/FeedSearchController.java
@@ -1,6 +1,7 @@
 package com.mulmeong.feed.read.api.presentation;
 
 import com.mulmeong.feed.read.api.application.FeedSearchService;
+import com.mulmeong.feed.read.api.dto.in.FeedRecommendRequestDto;
 import com.mulmeong.feed.read.api.dto.in.FeedSearchRequestDto;
 import com.mulmeong.feed.read.api.dto.in.IndexSyncRequestDto;
 import com.mulmeong.feed.read.api.dto.out.FeedResponseDto;

--- a/src/main/java/com/mulmeong/feed/read/api/presentation/FeedSearchController.java
+++ b/src/main/java/com/mulmeong/feed/read/api/presentation/FeedSearchController.java
@@ -2,14 +2,19 @@ package com.mulmeong.feed.read.api.presentation;
 
 import com.mulmeong.feed.read.api.application.FeedSearchService;
 import com.mulmeong.feed.read.api.dto.in.FeedSearchRequestDto;
+import com.mulmeong.feed.read.api.dto.in.IndexSyncRequestDto;
 import com.mulmeong.feed.read.api.dto.out.FeedResponseDto;
+import com.mulmeong.feed.read.api.vo.in.IndexSyncRequestVo;
 import com.mulmeong.feed.read.common.response.BaseResponse;
 import com.mulmeong.feed.read.common.utils.CursorPage;
+import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -28,7 +33,7 @@ public class FeedSearchController {
         - `title`, `content`, `categoryName`, `hashtags` 유사도 측정<br><br>
         - 가중치 기반의 `netLikes`, `createdAt` 내림차순<br><br>
         - `nextCursor` 변수를 반환하지만 내부 로직에서 사용하지 않음""")
-    @GetMapping("/search/feeds/{keyword}")
+    @GetMapping("/search/{keyword}/feeds")
     public BaseResponse<CursorPage<FeedResponseDto>> searchFeeds(
         @PathVariable String keyword,
         @RequestParam(required = false) Integer pageSize,
@@ -37,6 +42,14 @@ public class FeedSearchController {
         return new BaseResponse<>(
             feedSearchService.searchFeeds(
                 FeedSearchRequestDto.toDto(keyword, pageSize, pageNo)));
+    }
+
+    @Hidden
+    @PostMapping("/feeds/indexing")
+    public BaseResponse<Void> syncIndex(@RequestBody IndexSyncRequestVo requestVo) {
+
+        feedSearchService.syncIndex(IndexSyncRequestDto.toDto(requestVo));
+        return new BaseResponse<>();
     }
 
 }

--- a/src/main/java/com/mulmeong/feed/read/api/vo/in/IndexSyncRequestVo.java
+++ b/src/main/java/com/mulmeong/feed/read/api/vo/in/IndexSyncRequestVo.java
@@ -1,0 +1,11 @@
+package com.mulmeong.feed.read.api.vo.in;
+
+import lombok.Getter;
+
+@Getter
+public class IndexSyncRequestVo {
+
+    private String lastId;
+    private Integer limit;
+
+}

--- a/src/main/java/com/mulmeong/feed/read/common/client/AdminClient.java
+++ b/src/main/java/com/mulmeong/feed/read/common/client/AdminClient.java
@@ -1,0 +1,15 @@
+package com.mulmeong.feed.read.common.client;
+
+import com.mulmeong.feed.read.api.dto.client.CategoryVo;
+import com.mulmeong.feed.read.common.response.BaseResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@FeignClient(name = "admin-service", url = "${api.admin-service.url}")
+public interface AdminClient {
+
+    @GetMapping("/category/{categoryId}")
+    BaseResponse<CategoryVo> getCategory(@PathVariable Long categoryId);
+
+}

--- a/src/main/java/com/mulmeong/feed/read/common/client/MemberClient.java
+++ b/src/main/java/com/mulmeong/feed/read/common/client/MemberClient.java
@@ -1,0 +1,20 @@
+package com.mulmeong.feed.read.common.client;
+
+import com.mulmeong.feed.read.api.dto.client.CategoryDto;
+import com.mulmeong.feed.read.api.dto.client.HashtagDto;
+import com.mulmeong.feed.read.common.response.BaseResponse;
+import java.util.List;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@FeignClient(name = "member-service", url = "${api.member-service.url}")
+public interface MemberClient {
+
+    @GetMapping("/members/{memberUuid}/interests/categories")
+    BaseResponse<List<CategoryDto>> getInterestCategory(@PathVariable String memberUuid);
+
+    @GetMapping("/members/{memberUuid}/interests/hashtags")
+    BaseResponse<List<HashtagDto>> getInterestHashtag(@PathVariable String memberUuid);
+
+}

--- a/src/main/java/com/mulmeong/feed/read/common/client/UtilityClient.java
+++ b/src/main/java/com/mulmeong/feed/read/common/client/UtilityClient.java
@@ -1,0 +1,15 @@
+package com.mulmeong.feed.read.common.client;
+
+import com.mulmeong.feed.read.common.response.BaseResponse;
+import java.util.List;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@FeignClient(name = "utility-service", url = "${api.utility-service.url}")
+public interface UtilityClient {
+
+    @GetMapping("/members/{memberUuid}/all/followings")
+    BaseResponse<List<String>> getAllFollowings(@PathVariable String memberUuid);
+
+}

--- a/src/main/java/com/mulmeong/feed/read/common/config/KafkaConsumerConfig.java
+++ b/src/main/java/com/mulmeong/feed/read/common/config/KafkaConsumerConfig.java
@@ -3,6 +3,7 @@ package com.mulmeong.feed.read.common.config;
 import com.mulmeong.feed.read.api.domain.event.FeedCreateEvent;
 import com.mulmeong.feed.read.api.domain.event.FeedDeleteEvent;
 import com.mulmeong.feed.read.api.domain.event.FeedHashtagUpdateEvent;
+import com.mulmeong.feed.read.api.domain.event.FeedMetricsUpdateEvent;
 import com.mulmeong.feed.read.api.domain.event.FeedStatusUpdateEvent;
 import com.mulmeong.feed.read.api.domain.event.FeedUpdateEvent;
 import com.mulmeong.feed.read.common.exception.BaseException;
@@ -58,6 +59,11 @@ public class KafkaConsumerConfig {
     @Bean
     public ConcurrentKafkaListenerContainerFactory<String, FeedUpdateEvent> feedUpdateEventListener() {
         return kafkaListenerContainerFactory(FeedUpdateEvent.class);
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, FeedMetricsUpdateEvent> feedMetricsUpdateEventListener() {
+        return kafkaListenerContainerFactory(FeedMetricsUpdateEvent.class);
     }
 
     /**

--- a/src/main/java/com/mulmeong/feed/read/common/response/BaseResponseStatus.java
+++ b/src/main/java/com/mulmeong/feed/read/common/response/BaseResponseStatus.java
@@ -29,7 +29,10 @@ public enum BaseResponseStatus {
      */
     FEED_FORBIDDEN(HttpStatus.FORBIDDEN, false, 1003, "피드 접근 권한이 없습니다."),
     FEED_NOT_FOUND(HttpStatus.NOT_FOUND, false, 1004, "존재하지 않는 게시글 정보입니다."),
-    HASHTAG_DUPLICATE_KEY(HttpStatus.CONFLICT, false, 1009, "해시태그가 이미 존재합니다.");
+    HASHTAG_DUPLICATE_KEY(HttpStatus.CONFLICT, false, 1009, "해시태그가 이미 존재합니다."),
+    ELASTICSEARCH_DATA_MISMATCH(HttpStatus.NOT_FOUND, false, 1054,
+        "Elasticsearch 데이터가 동기화되지 않았습니다.");
+
 
     private final HttpStatus httpStatus;
     private final boolean isSuccess;


### PR DESCRIPTION
<!-- Title: [🚀 (Service名)] (AAA) 기능 구현 -->
<!-- Merge 방향 및 Branch 확인해주세요 -->
<!-- (괄호) 부분은 다 지우고 작성해주세요 -->

### 📅 2024.12.26

### 🌵 Branch
develop → release

### 📢 Description
- Elasticsearch 및 FeignClient 설정
- SyncIndex, 검색 및 추천 API 구현
- 비디오 데이터는 S3에 업로드된 후 변환 작업을 거쳐 지정된 S3 URL에 다시 업로드 되기까지 **평균적으로 약 9초**가 소요
=> Delay를 주지 않으면 해당 피드 게시글을 조회할 때 비디오 컨텐츠가 원활히 표시되지 않음
=> 피드 생성시 비디오 파일 하나당 10초의 비동기 Delay를 적용

이하 Pull Request 및 Issue 내용 참고

### 📦 Pull Request Number
- #20 
- #18 

### 💬 Issue Number
- #19 
- #14 

### 🔖 Note
- 배포 환경에 Elasticsearch & Kibana 구축 완료
- 페이지네이션에서 `pageNo`로 1보다 작은 요청값이 들어왔을 때 해당 `pageNo`는 1로 구성하고 반환하도록 수정 <br><br>

- 필터링 API 페이지네이션 offset 연산 수정
- 집계 데이터 수정 Event Consume 구현